### PR TITLE
Allowed unicode in usernames

### DIFF
--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -6,6 +6,8 @@ from config_models.admin import ConfigurationModelAdmin
 from student.models import UserProfile, UserTestGroup, CourseEnrollmentAllowed, DashboardConfiguration
 from student.models import CourseEnrollment, Registration, PendingNameChange, CourseAccessRole, CourseAccessRoleAdmin
 from ratelimitbackend import admin
+from edraak_validation import UnicodeUserAdmin
+from django.contrib.auth.models import User
 
 admin.site.register(UserProfile)
 
@@ -22,3 +24,6 @@ admin.site.register(PendingNameChange)
 admin.site.register(CourseAccessRole, CourseAccessRoleAdmin)
 
 admin.site.register(DashboardConfiguration, ConfigurationModelAdmin)
+
+# Edraak: Support Unicode in admin/user pages
+admin.site.register(User, UnicodeUserAdmin)

--- a/common/djangoapps/student/edraak_validation.py
+++ b/common/djangoapps/student/edraak_validation.py
@@ -1,0 +1,42 @@
+"""
+Allow Unicode in Admin and LMS.
+"""
+from django.contrib.auth.admin import UserAdmin
+from django import forms
+from ratelimitbackend import admin
+import re
+from django.contrib.auth.forms import UserCreationForm, UserChangeForm
+from django.core.validators import RegexValidator
+from django.utils.translation import ugettext_lazy as _
+
+unicode_username_re = re.compile(ur'^[\w .@_+-]+$', re.UNICODE)
+
+unicode_username_field = forms.RegexField(label=_("Username"),
+                                          max_length=30,
+                                          regex=unicode_username_re,
+                                          help_text=_("Required. 30 characters or fewer. Letters, digits and "
+                                                      "@/./+/-/_ only."),
+                                          error_messages={
+                                              'invalid': _("This value may contain only letters, numbers and"
+                                                           " @/./+/-/_ characters.")
+                                          })
+
+
+class UnicodeUserCreationForm(UserCreationForm):
+    username = unicode_username_field
+
+
+class UnicodeUserChangeForm(UserChangeForm):
+    username = unicode_username_field
+
+
+class UnicodeUserAdmin(UserAdmin):
+    form = UnicodeUserChangeForm
+    add_form = UnicodeUserCreationForm
+
+
+validate_username = RegexValidator(
+    unicode_username_re,
+    _("Enter a valid 'username' consisting of letters, numbers, spaces, underscores or hyphens."),
+    'invalid'
+)

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -19,7 +19,7 @@ from django.contrib import messages
 from django.core.context_processors import csrf
 from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
-from django.core.validators import validate_email, validate_slug, ValidationError
+from django.core.validators import validate_email, ValidationError
 from django.db import IntegrityError, transaction
 from django.http import (HttpResponse, HttpResponseBadRequest, HttpResponseForbidden,
                          Http404)
@@ -99,6 +99,8 @@ from shoppingcart.models import CourseRegistrationCode
 
 import analytics
 from eventtracking import tracker
+
+from edraak_validation import validate_username
 
 
 log = logging.getLogger("edx.student")
@@ -1450,9 +1452,10 @@ def create_account(request, post_override=None):  # pylint: disable-msg=too-many
         return JsonResponse(js, status=400)
 
     try:
-        validate_slug(post_vars['username'])
+        # Edraak Unicode support to usernames in LMS
+        validate_username(post_vars['username'])
     except ValidationError:
-        js['value'] = _("Username should only consist of A-Z and 0-9, with no spaces.")
+        js['value'] = _("Enter a valid 'username' consisting of letters, numbers, spaces, underscores or hyphens.")
         js['field'] = 'username'
         return JsonResponse(js, status=400)
 


### PR DESCRIPTION
@devalih This is done. Only usernames has Arabic allowed.
## What to Test
- Register in Arabic
- You can make a user with an Arabic username as an admin in `/admin`
- Names that contains invalid characters before this change don't make a problem 
