### PR TITLE
Edraak envs for CMS

### DIFF
--- a/cms/envs/edraak_aws.py
+++ b/cms/envs/edraak_aws.py
@@ -1,0 +1,8 @@
+from .aws import *
+from .edraak_common import *
+from lms.envs.edraak_aws import (
+    LMS_BASE,
+    SESSION_COOKIE_DOMAIN,
+    STATIC_ROOT_BASE,
+    STATIC_URL_BASE,
+)

--- a/cms/envs/edraak_common.py
+++ b/cms/envs/edraak_common.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from .aws import FEATURES
+
+from lms.envs.edraak_common import (
+    PLATFORM_NAME,
+    LANGUAGE_CODE,
+    SITE_NAME,
+    TIME_ZONE,
+    FEEDBACK_SUBMISSION_EMAIL,
+    PAYMENT_SUPPORT_EMAIL,
+    SERVER_EMAIL,
+    BUGS_EMAIL,
+    PRESS_EMAIL,
+    CONTACT_EMAIL,
+    COLLABORATE_EMAIL,
+    TECH_SUPPORT_EMAIL,
+    UNIVERSITY_EMAIL,
+    WIKI_ENABLED,
+    LANGUAGES,
+)

--- a/cms/envs/edraak_devstack.py
+++ b/cms/envs/edraak_devstack.py
@@ -1,0 +1,2 @@
+from .devstack import *
+from .edraak_common import *

--- a/lms/envs/edraak_aws.py
+++ b/lms/envs/edraak_aws.py
@@ -1,6 +1,9 @@
 from .aws import *
 from .edraak_common import *
 
+# WARNING: Don't just add/delete settings from here. Make sure the settings are
+# reflected in `cms/envs/edraak_aws.py`
+
 SESSION_COOKIE_DOMAIN = ".edraak.org"
 LMS_BASE = "edraak.org"
 STATIC_ROOT_BASE = "/edx/var/edxapp/staticfiles",

--- a/lms/envs/edraak_common.py
+++ b/lms/envs/edraak_common.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from .aws import FEATURES
 
+# WARNING: Don't just add/delete settings from here. Make sure the settings are
+# reflected in `cms/envs/edraak_common.py` and `cms/envs/edraak_aws.py`
+
 FEATURES['ENABLE_DISCUSSION_HOME_PANEL'] = False
 FEATURES['AUTH_USE_OPENID_PROVIDER'] = True
 
@@ -17,6 +20,7 @@ PLATFORM_TWITTER_ACCOUNT = "@edraak"
 FEEDBACK_SUBMISSION_EMAIL = "info@edraak.or"
 PAYMENT_SUPPORT_EMAIL = "info@edraak.org"
 SERVER_EMAIL = "dev@qrf.org"
+BUGS_EMAIL = "dev@qrf.org"
 PRESS_EMAIL = "syacoub@qrf.org"
 CONTACT_EMAIL = "info@edraak.org"
 COLLABORATE_EMAIL = "info@edraak.org"

--- a/lms/envs/edraak_devstack.py
+++ b/lms/envs/edraak_devstack.py
@@ -1,2 +1,5 @@
 from .devstack import *
 from .edraak_common import *
+
+# WARNING: Don't just add/delete settings from here. Make sure the settings are
+# reflected in `cms/envs/edraak_devstack.py`


### PR DESCRIPTION
Added the CMS edraak environment configs to be consistent with the the `lms` 

Card: https://trello.com/c/IXRSESEj
## What to Test

```
$ cd edx-platform
$ git fetch
$ git checkout edraak-cms-envs
```
- `./manage.py cms runserver --settings=edraak_devstack 0.0.0.0:8001` Should work properly with the `edraak_devstack.py` settings applied
- `paver run_all_servers --settings=edraak_devstack` and `paver run_all_servers --settings=edraak_aws` should work properly and run both of the LMS and the CMS with no issues.
