### PR TITLE
Fix Unicode issues with course ID values

### DIFF
--- a/cms/djangoapps/contentstore/views/helpers.py
+++ b/cms/djangoapps/contentstore/views/helpers.py
@@ -104,7 +104,7 @@ def xblock_studio_url(xblock, parent_xblock=None):
     elif category in ('chapter', 'sequential'):
         return u'{url}?show={usage_key}'.format(
             url=reverse_course_url('course_handler', xblock.location.course_key),
-            usage_key=urllib.quote(unicode(xblock.location))
+            usage_key=urllib.quote(unicode(xblock.location).encode('utf-8'))
         )
     else:
         return reverse_usage_url('container_handler', xblock.location)


### PR DESCRIPTION
Card: [CMS error, when opening a new course that have an arabic org name.](https://trello.com/c/roKoXIeH/348-cms-error-when-opening-a-new-course-that-have-an-arabic-org-name)
This PR contains the essential parts of https://github.com/edx/edx-platform/pull/5827.

Just to confirm, the tests have passed in edX CI if we have added only this change:

![image](https://cloud.githubusercontent.com/assets/645156/4896803/5207e82e-63ff-11e4-9d59-0b6283d0db39.png)
