### PR TITLE
Removed wrong `edraak` app

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1487,7 +1487,6 @@ INSTALLED_APPS = (
     'survey',
 
     # Edraak specific modules
-    'edraak',
     'edraak_misc',
     'edraak_contact',
     'edraak_bayt',


### PR DESCRIPTION
This happened because of bad git history rewrite (human error). Without this fix, the LMS cannot run!
