### PR TITLE
Fixed spacing of RTL icon in discussion

### DIFF
--- a/lms/static/sass/discussion/utilities/_shame.scss
+++ b/lms/static/sass/discussion/utilities/_shame.scss
@@ -18,8 +18,8 @@
   border: 1px solid $gray-l2 !important;
   border-radius: 3px !important;
   height: auto !important;
-  padding-left: ($baseline/4) !important;
-  padding-right: ($baseline/2 + 12px) !important; // Leave room for icon
+  @include padding-left($baseline/4 !important);
+  @include padding-right($baseline/2 + 12px !important); // Leave room for icon
   font-size: 12px !important;
 }
 


### PR DESCRIPTION
The search icon is misplaced in RTL platform. Card: https://trello.com/c/sUp9Mbkp/309-rtl-issues

**This PR flips the icon spacing only.**

This complements https://bitbucket.org/Edraak/edraak-theme/pull-request/5/give-some-space-to-the-long-search-arabic/diff
## English (OK)

![discussion-en](https://cloud.githubusercontent.com/assets/645156/4899668/ab7609b2-641e-11e4-9c30-b49f06254fc9.png)
## Arabic (Before, not broken)

![rtl-arabic-before](https://cloud.githubusercontent.com/assets/645156/4899676/bcfb5020-641e-11e4-8d3f-9fda06d908f5.png)
## Arabic (After, fixed)

![discussion-after](https://cloud.githubusercontent.com/assets/645156/4899691/dd456186-641e-11e4-8fb1-f8c370f7545f.png)
