### PR TITLE
Fixed libmagickwand-dev library name

### DIFF
--- a/requirements/system/ubuntu/apt-packages.txt
+++ b/requirements/system/ubuntu/apt-packages.txt
@@ -32,7 +32,7 @@ libreadline6-dev
 mongodb
 nodejs
 coffeescript
-addlibmagickwand
+libmagickwand-dev
 mysql-client
 virtualenvwrapper
 libgeos-ruby1.8


### PR DESCRIPTION
@devalih This should fix the #1 issue.
However, we might still need to run the command bellow on newly provisioned machines, if the update/provision doesn't install it.

```
$ cat /edx/app/edxapp/edx-platform/requirements/system/ubuntu/apt-packages.txt | xargs sudo apt-get install -yq
$ sudo su edxapp
$ pip install -r requirements/edx/edraak/certificates.txt
```
