### PR TITLE
Fixing opengraph/facebook preview in homepage when using a CDN

### DIFF
--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -2,6 +2,7 @@
 from staticfiles.storage import staticfiles_storage
 from pipeline_mako import compressed_css, compressed_js
 from django.utils.translation import get_language_bidi
+from urlparse import urlparse
 %>
 
 <%def name='url(file, raw=False)'><%
@@ -18,10 +19,14 @@ except:
     except:
         url = file
 
+    if urlparse(url).netloc:  # is absolute URL
+        prefix = ''
+    else:
+        schema = 'https' if is_secure else 'http'
+        prefix = '{schema}://{host}'.format(schema=schema, host=request.environ['HTTP_HOST'])
 
-    schema = 'https' if is_secure else 'http'
-    host = request.environ['HTTP_HOST']
-%>${schema}://${host}${url}${"?raw" if raw else ""}</%def>
+
+%>${prefix}${url}${"?raw" if raw else ""}</%def>
 
 <%def name='css(group, raw=False)'>
   <%


### PR DESCRIPTION
Card: https://trello.com/c/VHKSqFrO

It's not working because the image URL is being set to the following: 

```
 <meta property="og:image" content="https://www.edraak.orghttps://d2q9s3qze1y77b.cloudfront.net/static/themes/edraak/images/edraak_logo.54f03d320961.png" />
```
