### PR TITLE
Corrected openedx/LOC-67 resolution logic by removing `fuzzy` flag from poentries

### DIFF
--- a/pavelib/edraak.py
+++ b/pavelib/edraak.py
@@ -48,6 +48,10 @@ def cleanup_po_entry_conflicts(entry):
 
         if line.startswith(conflict_mark):
             entry.msgstr = u'\n'.join(lines[1:i])
+
+            while 'fuzzy' in entry.flags:
+                entry.flags.remove('fuzzy')
+
             return entry
 
     raise Exception('Undefined behaviour')


### PR DESCRIPTION
Task: https://app.asana.com/0/13296136706033/25254082720903