### PR TITLE
Fixed 500 error for `all_courses` page

### DIFF
--- a/lms/djangoapps/edraak_misc/views.py
+++ b/lms/djangoapps/edraak_misc/views.py
@@ -34,7 +34,7 @@ def check_student_grades(request):
 
 
 @ensure_csrf_cookie
-@cache_if_anonymous
+@cache_if_anonymous()
 def all_courses(request, extra_context={}, user=AnonymousUser()):
     """
     Render the edX main page.


### PR DESCRIPTION
Task: https://app.asana.com/0/13296136706033/25352312973110

Simple update to `@cache_if_anonymous` decorator because it has changed.