### PR TITLE
Fixed RTL icon margin in the studio

### DIFF
--- a/cms/static/sass/elements/_controls.scss
+++ b/cms/static/sass/elements/_controls.scss
@@ -199,7 +199,7 @@
   .icon {
     display: inline-block;
     vertical-align: middle;
-    margin-right: ($baseline/4);
+    @include margin-right($baseline/4);
   }
 }
 
@@ -327,7 +327,7 @@
     @include transition(all $tmg-f2 ease-in-out 0s);
     @extend %t-action1;
     display: inline-block;
-    margin-right: ($baseline/4);
+    @include margin-right($baseline/4);
     color: $gray-l3;
     vertical-align: middle;
   }


### PR DESCRIPTION
Task: [Bad RTL icon margin in the studio](https://app.asana.com/0/13296136706033/25107998734947)

Go to URL: https://studio.edraak.org/course/bayt.com/BA_104/2014

Before:

![image](https://cloud.githubusercontent.com/assets/645156/6168009/b81060e2-b2c9-11e4-814c-edfebd6bf59d.png)

After: 

![image](https://cloud.githubusercontent.com/assets/645156/6168025/f35d7aa4-b2c9-11e4-8df2-1bc8d5b6dc2b.png)
