### PR TITLE
Make math equation fields always LTR in CAPA problems

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -50,6 +50,10 @@ div.problem {
     }
   }
 
+  input.math {
+    direction: ltr; // Equations are always English
+  }
+
   .inline {
     display: inline;
   }


### PR DESCRIPTION
Task: https://app.asana.com/0/13296136706033/29960485105223