### PR TITLE
Allow language change for marketing site, and secured the /langchange/

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -338,6 +338,14 @@ VIDEO_UPLOAD_PIPELINE = ENV_TOKENS.get('VIDEO_UPLOAD_PIPELINE', VIDEO_UPLOAD_PIP
 PARSE_KEYS = AUTH_TOKENS.get("PARSE_KEYS", {})
 
 
+# Keep in pair with the values in the LMS
+# A list of allowed hosts e.g. ['www.example.com', 'courses.example.com']
+CSRF_TRUSTED_ORIGINS = ENV_TOKENS.get('CSRF_TRUSTED_ORIGINS')
+
+# e.g. '.example.org'
+CSRF_COOKIE_DOMAIN = ENV_TOKENS.get('CSRF_COOKIE_DOMAIN')
+
+
 # Video Caching. Pairing country codes with CDN URLs.
 # Example: {'CN': 'http://api.xuetangx.com/edx/video?s3_url='}
 VIDEO_CDN_URL = ENV_TOKENS.get('VIDEO_CDN_URL', {})

--- a/common/djangoapps/edraak_i18n/helpers.py
+++ b/common/djangoapps/edraak_i18n/helpers.py
@@ -1,0 +1,17 @@
+from django.utils.http import is_safe_url
+
+
+def get_any_safe_url(hosts, urls):
+    """
+    Get any safe URL from a list of URLs in any given host.
+
+    :param hosts: A list of hosts to mark as safe.
+    :param urls: A list of possible URLs.
+    :return: Any safe URL
+    """
+    for url in urls:
+        for host in hosts:
+            if is_safe_url(url, host):
+                return url
+
+    return None

--- a/common/djangoapps/edraak_i18n/urls.py
+++ b/common/djangoapps/edraak_i18n/urls.py
@@ -1,5 +1,5 @@
 from django.conf.urls import patterns, url
 
-urlpatterns = patterns('',
+urlpatterns = patterns('',  # no-pep8
     url(r'^changelang/$', 'edraak_i18n.views.set_language', name='edraak_setlang'),
 )

--- a/common/djangoapps/edraak_i18n/views.py
+++ b/common/djangoapps/edraak_i18n/views.py
@@ -1,21 +1,57 @@
-from django.views.i18n import set_language as django_set_language
-from django.views.decorators.csrf import csrf_exempt
-from dark_lang import DARK_LANGUAGE_KEY
-from django_locale.trans_real import LANGUAGE_SESSION_KEY
-from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
 from django import http
+from django.conf import settings
+
+from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
+from django.utils.translation import check_for_language
+
+from django_locale.trans_real import LANGUAGE_SESSION_KEY
+from dark_lang import DARK_LANGUAGE_KEY
 
 
-@csrf_exempt
+from helpers import get_any_safe_url
+
+
 def set_language(request):
+    """
+    A re-implementation of django_set_language that is suitable of Edraak's edX platform.
 
-    auth_user = request.user.is_authenticated()
-    lang_code = request.POST.get('language', None)
+    It allows the user to redirect to the marketing site as well as the LMS.
 
-    request.session[LANGUAGE_SESSION_KEY] = lang_code
+    :param request: a request object for the view.
+    :return HttpResponseRedirect: Redirects the user to the next safe URL.
+    """
 
-    if auth_user:
-        set_user_preference(request.user, DARK_LANGUAGE_KEY, lang_code)
+    default_redirect_hosts = (
+        request.get_host(),
+    )
 
-    return django_set_language(request)
-    # we can return a simple redirect response, but I left this in place just in case !
+    hosts = getattr(settings, 'SAFE_REDIRECT_HOSTS', default_redirect_hosts)
+
+    safe_url = get_any_safe_url(
+        hosts=hosts,
+        urls=(
+            request.REQUEST.get('next'),
+            request.META.get('HTTP_REFERER'),
+            '/',
+        )
+    )
+
+    response = http.HttpResponseRedirect(safe_url)
+
+    if request.method == 'POST':
+        lang_code = request.POST.get('language', None)
+
+        if lang_code and check_for_language(lang_code):
+
+            if request.user.is_authenticated():
+                set_user_preference(request.user, DARK_LANGUAGE_KEY, lang_code)
+
+            if hasattr(request, 'session'):
+                request.session[LANGUAGE_SESSION_KEY] = lang_code
+            else:
+                response.set_cookie(settings.LANGUAGE_COOKIE_NAME, lang_code)
+
+    # Prevents accidental refresh: https://en.wikipedia.org/wiki/Post/Redirect/Get
+    response.status_code = 303
+
+    return response

--- a/common/templates/widgets/_language-change.html
+++ b/common/templates/widgets/_language-change.html
@@ -6,6 +6,8 @@ from django.core.urlresolvers import reverse
 <form id="edraak-language-form" action="${reverse('edraak_setlang')}"
       method="POST" style="display: none">
 
+    <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }" />
+
     % if translation.get_language() == 'ar':
         <input type="hidden" name="language" value="en">
     % else:

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -587,6 +587,19 @@ REGISTRATION_CODE_LENGTH = ENV_TOKENS.get('REGISTRATION_CODE_LENGTH', 8)
 BAYT_SECRET_KEY = AUTH_TOKENS.get("BAYT_SECRET_KEY")
 BAYT_BASE = ENV_TOKENS.get("BAYT_BASE")
 
+# Safe URL redirects for the LMS and marketing
+# A list of allowed hosts e.g. ['www.example.com', 'courses.example.com']
+SAFE_REDIRECT_HOSTS = ENV_TOKENS.get('SAFE_REDIRECT_HOSTS')
+
+
+# CSRF settings are used for language change forms, but it can have other usages as well
+# A list of allowed hosts e.g. ['www.example.com', 'courses.example.com']
+CSRF_TRUSTED_ORIGINS = ENV_TOKENS.get('CSRF_TRUSTED_ORIGINS')
+
+# e.g. '.example.org'
+CSRF_COOKIE_DOMAIN = ENV_TOKENS.get('CSRF_COOKIE_DOMAIN')
+
+
 # When the platform should give up on SMTP-based email verification
 EMAIL_VERIFICATION_SMTP_TIMEOUT = ENV_TOKENS.get("EMAIL_VERIFICATION_SMTP_TIMEOUT", 4)
 


### PR DESCRIPTION
Using this feature the marketing site can post a secure request (through CSRF) to the LMS in order to change the language and then redirect back to the page in the LMS.

This PR is part of a group:

 - Marketing: https://bitbucket.org/Edraak/marketing-site/pull-requests/158
 - Platform: https://github.com/Edraak/edx-platform/pull/101
 - Theme: https://bitbucket.org/Edraak/edraak-2015-theme/pull-requests/11