### PR TITLE
Allow Arabic username in combined registration form

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -44,7 +44,10 @@ from lms.envs.common import (
     PROFILE_IMAGE_SECRET_KEY, PROFILE_IMAGE_MIN_BYTES, PROFILE_IMAGE_MAX_BYTES,
     # The following setting is included as it is used to check whether to
     # display credit eligibility table on the CMS or not.
-    ENABLE_CREDIT_ELIGIBILITY, YOUTUBE_API_KEY
+    ENABLE_CREDIT_ELIGIBILITY, YOUTUBE_API_KEY,
+
+    # Unicode usernames
+    USERNAME_PATTERN, USERNAME_REGEX
 )
 from path import path
 from warnings import simplefilter
@@ -1022,7 +1025,3 @@ CREDIT_PROVIDER_TIMESTAMP_EXPIRATION = 15 * 60
 ################################ Deprecated Blocks Info ################################
 
 DEPRECATED_BLOCK_TYPES = ['peergrading', 'combinedopenended']
-
-# This pattern allow space in username
-USERNAME_PATTERN = r'(?P<username>[\w .@_+-]+)'
-

--- a/common/djangoapps/student/edraak_validation.py
+++ b/common/djangoapps/student/edraak_validation.py
@@ -10,7 +10,7 @@ from django.core.validators import RegexValidator
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 
-unicode_username_re = re.compile(settings.USERNAME_PATTERN, re.UNICODE)
+unicode_username_re = re.compile(settings.USERNAME_REGEX, re.UNICODE)
 
 unicode_username_field = forms.RegexField(label=_("Username"),
                                           max_length=30,

--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -19,6 +19,7 @@ from util.password_policy_validators import (
     validate_password_complexity,
     validate_password_dictionary,
 )
+from student.edraak_validation import validate_username
 
 
 class PasswordResetFormNoActive(PasswordResetForm):
@@ -103,15 +104,15 @@ class AccountCreationForm(forms.Form):
     validation, not rendering.
     """
     # TODO: Resolve repetition
-    username = forms.SlugField(
+    username = forms.CharField(
         min_length=2,
         max_length=30,
         error_messages={
             "required": _USERNAME_TOO_SHORT_MSG,
-            "invalid": _("Username should only consist of A-Z and 0-9, with no spaces."),
             "min_length": _USERNAME_TOO_SHORT_MSG,
             "max_length": _("Username cannot be more than %(limit_value)s characters long"),
-        }
+        },
+        validators=[validate_username],  # Allow Unicode usernames
     )
     email = forms.EmailField(
         max_length=75,  # Limit per RFCs is 254, but User's email field in django 1.4 only takes 75

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -598,7 +598,10 @@ USAGE_ID_PATTERN = r'(?P<usage_id>(?:i4x://?[^/]+/[^/]+/[^/]+/[^@]+(?:@[^/]+)?)|
 
 
 # This pattern allow space in username
-USERNAME_PATTERN = r'(?P<username>[\w .@_+-]+)'
+_USERNAME_REGEX_PART = '[\w .@_+-]+'
+USERNAME_REGEX = r'^{}$'.format(_USERNAME_REGEX_PART)
+USERNAME_PATTERN = r'(?P<username>{})'.format(_USERNAME_REGEX_PART)
+
 
 
 ############################## EVENT TRACKING #################################


### PR DESCRIPTION
Allow Arabic/Unicode username in the new (aka combined) registration form.


@devalih What to test:

- [x] Registration form
- [x] Course enrollment with the marketing site
- [x] CMS
- [x] Admin panel

The username should always contain only only letters, numbers and @/./+/-/_ characters.