### PR TITLE
Reset password email translation fixup: Use platform_name instead of site_name

### DIFF
--- a/conf/locale/babel_third_party.cfg
+++ b/conf/locale/babel_third_party.cfg
@@ -4,3 +4,6 @@ input_encoding = utf-8
 
 [django: **/template/**.html]
 input_encoding = utf-8
+
+[django: **/templates/registration/**.txt]
+input_encoding = utf-8

--- a/lms/templates/registration/password_reset_email.html
+++ b/lms/templates/registration/password_reset_email.html
@@ -1,5 +1,8 @@
+
 {% load i18n %}{% load url from future %}{% autoescape off %}
-{% blocktrans %}You're receiving this e-mail because you requested a password reset for your user account at {{ site_name }}.{% endblocktrans %}
+
+{# Translators: Edraak-specific #}
+{% blocktrans %}You're receiving this e-mail because you requested a password reset for your user account at {{ platform_name }}.{% endblocktrans %}
 
 {% trans "Please go to the following page and choose a new password:" %}
 {% block reset_link %}

--- a/lms/templates/registration/password_reset_subject.txt
+++ b/lms/templates/registration/password_reset_subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}{% autoescape off %}
+{# Translators: Edraak-specific #}
+{% blocktrans %}Password reset on {{ platform_name }}{% endblocktrans %}
+{% endautoescape %}


### PR DESCRIPTION
Solves task: https://app.asana.com/0/13296136706033/53456375649382


**Note:** this [used to be in `edraak-theme`](https://bitbucket.org/Edraak/edraak-theme/commits/5575aecb79fc3cf95b1af10eb351314954beb004) but we forgot to re-add it after the latest refactoring.