### PR TITLE
Fix gettext guidance violation

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/combinedopenended/display.coffee
+++ b/common/lib/xmodule/xmodule/js/src/combinedopenended/display.coffee
@@ -325,7 +325,7 @@ class @CombinedOpenEnded
         @submit_button.hide()
         @queueing()
         @grader_status = @$(@grader_status_sel)
-        @grader_status.html("<span class='grading'>" + gettext "Your response has been submitted. Please check back later for your grade." + "</span>")
+        @grader_status.html("<span class='grading'>" + (gettext "Your response has been submitted. Please check back later for your grade.") + "</span>")
       else if @child_type == "selfassessment"
         @setup_score_selection()
     else if @child_state == 'post_assessment'

--- a/lms/static/js/student_account/views/account_settings_fields.js
+++ b/lms/static/js/student_account/views/account_settings_fields.js
@@ -1,8 +1,8 @@
 ;(function (define, undefined) {
     'use strict';
     define([
-        'gettext', 'jquery', 'underscore', 'backbone', 'js/mustache', 'js/views/fields'
-    ], function (gettext, $, _, Backbone, RequireMustache, FieldViews) {
+        'gettext', 'jquery', 'underscore', 'backbone', 'js/views/fields'
+    ], function (gettext, $, _, Backbone, FieldViews) {
 
         var AccountSettingsFieldViews = {};
 
@@ -10,9 +10,10 @@
 
             successMessage: function() {
                 return this.indicators.success + interpolate_text(
-                    // TODO: remove Edraak specific after merging in edx
-                    // Translators: Edraak-specific
-                    gettext('We\'ve sent a confirmation message to {new_email_address}. Click the link in the message to update your email address.'),
+                    gettext(
+                        /* jshint maxlen: false */
+                        'We\'ve sent a confirmation message to {new_email_address}. Click the link in the message to update your email address.'
+                    ),
                     {'new_email_address': this.fieldValue()}
                 );
             }
@@ -77,9 +78,10 @@
 
             successMessage: function () {
                 return this.indicators.success + interpolate_text(
-                    // TODO: remove Edraak specific after merging in edx
-                    // Translators: Edraak-specific
-                    gettext('We\'ve sent a message to {email_address}. Click the link in the message to reset your password.'),
+                    gettext(
+                        /* jshint maxlen: false */
+                        'We\'ve sent a message to {email_address}. Click the link in the message to reset your password.'
+                    ),
                     {'email_address': this.model.get(this.options.emailAttribute)}
                 );
             }
@@ -97,12 +99,13 @@
             },
 
             saveValue: function () {
-                var attributes = {},
-                    value = this.fieldValue() ? [{'code': this.fieldValue()}] : [];
-                attributes[this.options.valueAttribute] = value;
-                this.saveAttributes(attributes);
+                if (this.persistChanges === true) {
+                    var attributes = {},
+                        value = this.fieldValue() ? [{'code': this.fieldValue()}] : [];
+                    attributes[this.options.valueAttribute] = value;
+                    this.saveAttributes(attributes);
+                }
             }
-
         });
 
         AccountSettingsFieldViews.AuthFieldView = FieldViews.LinkFieldView.extend({
@@ -113,11 +116,20 @@
             },
 
             render: function () {
+                var linkTitle;
+                if (this.options.connected) {
+                    linkTitle = gettext('Unlink');
+                } else if (this.options.acceptsLogins) {
+                    linkTitle = gettext('Link')
+                } else {
+                    linkTitle = ''
+                }
+
                 this.$el.html(this.template({
                     id: this.options.valueAttribute,
                     title: this.options.title,
                     screenReaderTitle: this.options.screenReaderTitle,
-                    linkTitle: this.options.connected ? gettext('Unlink') : gettext('Link'),
+                    linkTitle: linkTitle,
                     linkHref: '',
                     message: this.helpMessage
                 }));


### PR DESCRIPTION
This edX's fix for this TASK: [Account setting: The "English" validation message is displaying for the "تغيير كلمة السر" under the account setting Arabic version ](https://app.asana.com/0/35717934599877/57005855510148/)

[My fix](https://github.com/Edraak/edx-platform/pull/118) was merged earlier, but I've cherry-picked edX's fix so we can easily update our platform later.

1. No string concatenation should be used in the gettext function.
2. Some extra parentheses should be used in coffee script, to avoid the following situation: in coffee script, the call ```gettext "text to be extracted" + "text should not be extracted"``` will be translated into ```gettext("text to be extracted" + "text should not be extracted")``` rather than ```gettext("text to be extracted") + "text should not be extracted"```.