### PR TITLE
Edraak/discussions edit post fix

### DIFF
--- a/lms/static/sass/discussion/_discussion.scss
+++ b/lms/static/sass/discussion/_discussion.scss
@@ -110,7 +110,6 @@ body.discussion {
   }
 
   .wmd-panel {
-    min-width: 500px;
     width: 100%;
   }
 

--- a/lms/static/sass/discussion/_mixins.scss
+++ b/lms/static/sass/discussion/_mixins.scss
@@ -98,11 +98,11 @@
 
 @mixin discussion-wmd-preview {
   padding: ($baseline/2) $baseline;
-  width: 100%;
-  color: #333;
+  width: auto;
+  color: $gray-d3;
 
   ol, ul { // Fix up the RTL-only _reset.scss, but only in specific places
-    @include padding-left(40px);
+    @include padding-left($baseline*2);
     @include padding-right(0);
   }
 }

--- a/lms/static/sass/discussion/views/_create-edit-post.scss
+++ b/lms/static/sass/discussion/views/_create-edit-post.scss
@@ -6,10 +6,9 @@
 .edit-post-form {
   @include clearfix();
   box-sizing: border-box;
-  margin: 0;
+  margin: 0 auto;
   border-radius: 3px;
-  padding: ($baseline*2);
-  min-width: 760px;
+  padding: ($baseline);
   max-width: 1180px;
   background: $gray-l5;
 


### PR DESCRIPTION
TASKS:

1. [Issue #2 : The Horizontal Rule displays out of the " Preview pane " border ](https://app.asana.com/0/64330652734141/64333111492502)

2. [Issue#2: "Edit Response" and "Edit Comment "text boxes displays improperly ( Out of the border )](https://app.asana.com/0/35717934599877/63606800413665)

These changes are picked manually from different [edx-platform](https://github.com/Edraak/edx-platform) pulls, and I didn't cherry-pick them because these changes are based on changes we do not have in this platform.