### PR TITLE
Redirect successful enrollment to the marketing success page

### DIFF
--- a/common/djangoapps/course_modes/helpers.py
+++ b/common/djangoapps/course_modes/helpers.py
@@ -1,0 +1,28 @@
+from django.conf import settings
+from django.core.urlresolvers import reverse
+
+
+def get_mktg_enroll_success_redirect(course_id):
+    """
+    Provide a success page option after course enrollment in the marketing site.
+
+    This provides an alternative to redirecting the user to the dashboard after successful enrollment.
+
+    This function is enabled once `MKTG_URLS['ENROLL_SUCCESS']` is set in the settings.
+
+    :param course_id: Course ID as string.
+    :return (unicode) Redirect URL.
+    """
+    if settings.FEATURES.get('ENABLE_MKTG_SITE'):
+        enroll_success_url = settings.MKTG_URLS.get('ENROLL_SUCCESS')
+
+        if enroll_success_url:
+            # TODO: Handle language-based URL e.g. /about/ vs. /en/about/
+            return '{root}{path}'.format(
+                root=settings.MKTG_URLS['ROOT'],
+                path=enroll_success_url.format(
+                    course_id=course_id,
+                ),
+            )
+
+    return reverse('dashboard')

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -25,6 +25,8 @@ from xmodule.modulestore.django import modulestore
 
 from embargo import api as embargo_api
 
+from helpers import get_mktg_enroll_success_redirect
+
 
 class ChooseModeView(View):
     """View used when the user is asked to pick a mode.
@@ -86,7 +88,7 @@ class ChooseModeView(View):
         # in the "honor" track by this point, so we send the user
         # to the dashboard.
         if not CourseMode.has_verified_mode(modes):
-            return redirect(reverse('dashboard'))
+            return redirect(get_mktg_enroll_success_redirect(course_id))
 
         # If a user has already paid, redirect them to the dashboard.
         if is_active and (enrollment_mode in CourseMode.VERIFIED_MODES + [CourseMode.NO_ID_PROFESSIONAL_MODE]):


### PR DESCRIPTION
Summary:
 - Solved a bug: [The "Success" page does not display for the user who enrolls for a course from the "Register" or "Login" pages](https://app.asana.com/0/64330652734141/51742100725416)


**This is PR is within a group of 3 PRs:** 
 - [Configuration feature PR](https://bitbucket.org/Edraak/configuration/pull-requests/1/added-mktg_urlsenroll_success-to-prod-and/diff)
 - [edx-platform PR](https://github.com/Edraak/edx-platform/pull/128).
 - [marketing PR](https://bitbucket.org/Edraak/marketing-site/pull-requests/195/moved-the-enroll-success-page-into-a/diff)