### PR TITLE
Calculator help popup fixes

### DIFF
--- a/lms/static/coffee/src/calculator.coffee
+++ b/lms/static/coffee/src/calculator.coffee
@@ -14,7 +14,7 @@
 class @Calculator
   constructor: ->
     @hintButton = $('#calculator_hint')
-    @hintPopup = $('.help')
+    @hintPopup = $('.calc-help-popup')
     @hintsList = @hintPopup.find('.hint-item')
     @selectHint($('#' + @hintPopup.attr('aria-activedescendant')));
 

--- a/lms/static/sass/course/modules/_calculator.scss
+++ b/lms/static/sass/course/modules/_calculator.scss
@@ -11,7 +11,7 @@
   -webkit-appearance: none;
   width: 100%;
   direction: ltr;
-  
+
   &.open {
     bottom: -36px;
   }
@@ -52,17 +52,6 @@
     max-height: 90px;
     background: $black;
     color: $white;
-
-    // UI: input help table
-    .calculator-input-help-table {
-      margin: ($baseline/2) 0;
-
-      tr th, tr td {
-        vertical-align: top;
-        border: 1px solid $gray-l4;
-        padding: ($baseline/2);
-      }
-    }
 
     form {
       @extend .clearfix;
@@ -170,47 +159,88 @@
               color: $white;
             }
           }
-
-          .help {
-            @include transition(none);
-            background: $white;
-            border-radius: 3px;
-            box-shadow: 0 0 3px #999;
-            color: #333;
-            padding: 10px;
-            position: absolute;
-            right: -40px;
-            bottom: 57px;
-            width: 600px;
-            overflow: hidden;
-            pointer-events: none;
-            display: none;
-            margin: 0;
-            list-style: none;
-
-            &.shown {
-              display: block;
-              pointer-events: auto;
-            }
-
-            .bold {
-              font-weight: bold;
-            }
-
-            p, p+p {
-              margin: 0;
-            }
-
-            .calc-postfixes {
-              margin: 10px auto;
-
-              td, th {
-                padding: 2px 15px;
-              }
-            }
-          }
         }
       }
     }
+  }
+}
+
+@mixin position-calc-help-popup($ie) {
+    // Position the calc-help popup, in the center of the screen for
+    // modern browsers.
+    // While maintaining the old edX position for IE9 and bellow
+    // Because they don't support `calc`, `vw` `vh` of CSS.
+    box-sizing: if($ie, content-box, border-box);
+    max-height: if($ie, none, calc(100vh - 115px));
+    bottom: if($ie, 57px, 90px);
+    width: if($ie, 600px, 60vw);
+    @include left(if($ie, auto, 20vw));
+    @include right(if($ie, -40px, auto));
+
+    overflow: if($ie, hidden, auto);
+
+    @media screen and (max-width: 991px) {
+        // Full screen for mobile
+        width: if($ie, 600px, 95vw);
+
+        // TODO: Consider using another centering method, other than `calc`.
+        @include left( if($ie, auto, calc(1vw - 5px)) );
+    }
+}
+
+.calc-help-popup {
+  @include transition(none);
+  background: $white;
+  border-radius: 3px;
+  box-shadow: // Standard 3px black shadow.
+              0 0 3px #999,
+              // Places a overlay black transparent popup background.
+              0 0 0 4000em rgba(0, 0, 0, 0.20);
+
+  color: #333;
+  padding: 10px;
+  position: absolute;
+
+  pointer-events: none;
+  display: none;
+  margin: 0;
+  list-style: none;
+
+  @include position-calc-help-popup($ie: false);
+
+  // UI: input help table
+  .calculator-input-help-table {
+    margin: ($baseline/2) 0;
+
+    tr th, tr td {
+      vertical-align: top;
+      border: 1px solid $gray-l4;
+      padding: ($baseline/2);
+    }
+  }
+
+  &.shown {
+    display: block;
+    pointer-events: auto;
+  }
+
+  .bold {
+    font-weight: bold;
+  }
+
+  p, p+p {
+    margin: 0;
+  }
+
+  .calc-postfixes {
+    margin: 10px auto;
+
+    td, th {
+      padding: 2px 15px;
+    }
+  }
+
+  .lte9 & {
+    @include position-calc-help-popup($ie: true);
   }
 }

--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -58,11 +58,11 @@ from django.core.urlresolvers import reverse
         </tr>
         <tr>
           <th scope="row">${_("Numbers")}</th>
-          <td>${_("Integers")}<br />
+          <td dir="auto">${_("Integers")}<br />
             ${_("Fractions")}<br />
             ${_("Decimals")}
           </td>
-          <td>2520<br />
+          <td dir="auto">2520<br />
             2/3<br />
             3.14, .98
           </td>
@@ -70,7 +70,7 @@ from django.core.urlresolvers import reverse
         <tr>
           <th scope="row">${_("Operators")}</th>
           ## Translators: Please do not translate mathematical symbols.
-          <td>${_("+ - * / (add, subtract, multiply, divide)")}<br />
+          <td dir="auto">${_("+ - * / (add, subtract, multiply, divide)")}<br />
             ## Translators: Please do not translate mathematical symbols.
             ${_("^ (raise to a power)")}<br />
             ## Translators: Please do not translate mathematical symbols.
@@ -78,7 +78,7 @@ from django.core.urlresolvers import reverse
             ## Translators: Please do not translate mathematical symbols.
             ${_("|| (parallel resistors)")}
           </td>
-          <td>x+(2*y)/x-1
+          <td dir="auto">x+(2*y)/x-1
             x^(n+1)<br />
             v_IN+v_OUT<br />
             1||2
@@ -86,56 +86,56 @@ from django.core.urlresolvers import reverse
         </tr>
         <tr>
           <th scope="row">${_("Greek letters")}</th>
-          <td>${_("Name of letter")}</td>
-          <td>alpha<br />
+          <td dir="auto">${_("Name of letter")}</td>
+          <td dir="auto">alpha<br />
             lambda
           </td>
         </tr>
         <tr>
           <th scope="row">${_("Constants")}</th>
-          <td>c, e, g, i, j, k, pi, q, T</td>
-          <td>20*c<br />
+          <td dir="auto">c, e, g, i, j, k, pi, q, T</td>
+          <td dir="auto">20*c<br />
             418*T
           </td>
         </tr>
         <tr>
           <th scope="row">${_("Affixes")}</th>
-          <td>${_("Percent sign (%) and metric affixes (d, c, m, u, n, p, k, M, G, T)")}</td>
-          <td>20%<br />
+          <td dir="auto">${_("Percent sign (%) and metric affixes (d, c, m, u, n, p, k, M, G, T)")}</td>
+          <td dir="auto">20%<br />
             20c<br />
             418T
           </td>
         </tr>
         <tr>
           <th scope="row">${_("Basic functions")}</th>
-          <td>abs, exp, fact or factorial, ln, log2, log10, sqrt</td>
-          <td>abs(x+y)<br />
+          <td dir="auto">abs, exp, fact or factorial, ln, log2, log10, sqrt</td>
+          <td dir="auto">abs(x+y)<br />
             sqrt(x^2-y)
           </td>
         </tr>
         <tr>
           <th scope="row">${_("Trigonometric functions")}</th>
-          <td>sin, cos, tan, sec, csc, cot<br />
+          <td dir="auto">sin, cos, tan, sec, csc, cot<br />
             arcsin, sinh, arcsinh, etc.<br />
           </td>
-          <td>sin(4x+y)<br />
+          <td dir="auto">sin(4x+y)<br />
             arccsch(4x+y)
           </td>
-          <td></td>
+          <td dir="auto"></td>
         </tr>
         <tr>
           ## Translators: Please see http://en.wikipedia.org/wiki/Scientific_notation
           <th scope="row">${_("Scientific notation")}</th>
           ## Translators: 10^ is a mathematical symbol. Please do not translate.
-          <td>${_("10^ and the exponent")}</td>
-          <td>10^-9</td>
+          <td dir="auto">${_("10^ and the exponent")}</td>
+          <td dir="auto">10^-9</td>
         </tr>
         <tr>
           ## Translators: this is part of scientific notation. Please see http://en.wikipedia.org/wiki/Scientific_notation#E_notation
           <th scope="row">${_("e notation")}</th>
           ## Translators: 1e is a mathematical symbol. Please do not translate.
-          <td>${_("1e and the exponent")}</td>
-          <td>1e-9</td>
+          <td dir="auto">${_("1e and the exponent")}</td>
+          <td dir="auto">1e-9</td>
         </tr>
       </tbody>
     </table>

--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -18,120 +18,6 @@ from django.core.urlresolvers import reverse
           <p class="sr" id="hint-instructions">${_('Use the arrow keys to navigate the tips or use the tab key to return to the calculator')}</p>
 
           <button id="calculator_hint" aria-haspopup="true" aria-expanded="false" aria-controls="calculator_input_help" aria-describedby="hint-instructions"><span class="calc-hint sr">${_("Hints")}</span></button>
-
-          <ul id="calculator_input_help" class="help" aria-hidden="true">
-            <li class="hint-item" id="hint-moreinfo">
-                <p><span class="bold">${_("For detailed information, see {math_link_start}Entering Mathematical and Scientific Expressions{math_link_end} in the {guide_link_start}edX Guide for Students{guide_link_end}.").format(
-                  math_link_start='<a href="http://edx-guide-for-students.readthedocs.org/en/latest/SFD_mathformatting.html">',
-                  math_link_end='</a>',
-                  guide_link_start='<a href="http://edx-guide-for-students.readthedocs.org/en/latest/index.html">',
-                  guide_link_end='</a>',
-                )}</span></p>
-            </li>
-
-            <li class="hint-item" id="hint-tips"><p><span class="bold">${_("Tips")}:</span> </p>
-              <ul>
-                <li class="hint-item" id="hint-paren"><p>${_("Use parentheses () to make expressions clear. You can use parentheses inside other parentheses.")}</p></li>
-                <li class="hint-item" id="hint-spaces"><p>${_("Do not use spaces in expressions.")}</p></li>
-                <li class="hint-item" id="hint-howto-constants"><p>${_("For constants, indicate multiplication explicitly (example: 5*c).")}</p></li>
-                <li class="hint-item" id="hint-howto-maffixes"><p>${_("For affixes, type the number and affix without a space (example: 5c).")}</p></li>
-                <li class="hint-item" id="hint-howto-functions"><p>${_("For functions, type the name of the function, then the expression in parentheses.")}</p></li>
-              </ul>
-            </li>
-
-            <li class="hint-item" id="hint-list">
-              <table class="calculator-input-help-table">
-                <tbody>
-                  <tr>
-                    <th scope="col">${_("To Use")}</th>
-                    <th scope="col">${_("Type")}</th>
-                    <th scope="col">${_("Examples")}</th>
-                  </tr>
-                  <tr>
-                    <th scope="row">${_("Numbers")}</th>
-                    <td>${_("Integers")}<br />
-                      ${_("Fractions")}<br />
-                      ${_("Decimals")}
-                    </td>
-                    <td>2520<br />
-                      2/3<br />
-                      3.14, .98
-                    </td>
-                  </tr>
-                  <tr>
-                    <th scope="row">${_("Operators")}</th>
-                    ## Translators: Please do not translate mathematical symbols.
-                    <td>${_("+ - * / (add, subtract, multiply, divide)")}<br />
-                      ## Translators: Please do not translate mathematical symbols.
-                      ${_("^ (raise to a power)")}<br />
-                      ## Translators: Please do not translate mathematical symbols.
-                      ${_("_ (add a subscript)")}<br />
-                      ## Translators: Please do not translate mathematical symbols.
-                      ${_("|| (parallel resistors)")}
-                    </td>
-                    <td>x+(2*y)/x-1
-                      x^(n+1)<br />
-                      v_IN+v_OUT<br />
-                      1||2
-                    </td>
-                  </tr>
-                  <tr>
-                    <th scope="row">${_("Greek letters")}</th>
-                    <td>${_("Name of letter")}</td>
-                    <td>alpha<br />
-                      lambda
-                    </td>
-                  </tr>
-                  <tr>
-                    <th scope="row">${_("Constants")}</th>
-                    <td>c, e, g, i, j, k, pi, q, T</td>
-                    <td>20*c<br />
-                      418*T
-                    </td>
-                  </tr>
-                  <tr>
-                    <th scope="row">${_("Affixes")}</th>
-                    <td>${_("Percent sign (%) and metric affixes (d, c, m, u, n, p, k, M, G, T)")}</td>
-                    <td>20%<br />
-                      20c<br />
-                      418T
-                    </td>
-                  </tr>
-                  <tr>
-                    <th scope="row">${_("Basic functions")}</th>
-                    <td>abs, exp, fact or factorial, ln, log2, log10, sqrt</td>
-                    <td>abs(x+y)<br />
-                      sqrt(x^2-y)
-                    </td>
-                  </tr>
-                  <tr>
-                    <th scope="row">${_("Trigonometric functions")}</th>
-                    <td>sin, cos, tan, sec, csc, cot<br />
-                      arcsin, sinh, arcsinh, etc.<br />
-                    </td>
-                    <td>sin(4x+y)<br />
-                      arccsch(4x+y)
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    ## Translators: Please see http://en.wikipedia.org/wiki/Scientific_notation
-                    <th scope="row">${_("Scientific notation")}</th>
-                    ## Translators: 10^ is a mathematical symbol. Please do not translate.
-                    <td>${_("10^ and the exponent")}</td>
-                    <td>10^-9</td>
-                  </tr>
-                  <tr>
-                    ## Translators: this is part of scientific notation. Please see http://en.wikipedia.org/wiki/Scientific_notation#E_notation
-                    <th scope="row">${_("e notation")}</th>
-                    ## Translators: 1e is a mathematical symbol. Please do not translate.
-                    <td>${_("1e and the exponent")}</td>
-                    <td>1e-9</td>
-                  </tr>
-                </tbody>
-              </table>
-            </li>
-          </ul>
         </div>
       </div>
 
@@ -140,4 +26,118 @@ from django.core.urlresolvers import reverse
       <input type="text" id="calculator_output" readonly />
     </form>
   </div>
-  </div>
+</div>
+
+<ul id="calculator_input_help" class="calc-help-popup" aria-hidden="true">
+  <li class="hint-item" id="hint-moreinfo">
+      <p><span class="bold">${_("For detailed information, see {math_link_start}Entering Mathematical and Scientific Expressions{math_link_end} in the {guide_link_start}edX Guide for Students{guide_link_end}.").format(
+        math_link_start='<a href="http://edx-guide-for-students.readthedocs.org/en/latest/SFD_mathformatting.html">',
+        math_link_end='</a>',
+        guide_link_start='<a href="http://edx-guide-for-students.readthedocs.org/en/latest/index.html">',
+        guide_link_end='</a>',
+      )}</span></p>
+  </li>
+
+  <li class="hint-item" id="hint-tips"><p><span class="bold">${_("Tips")}:</span> </p>
+    <ul>
+      <li class="hint-item" id="hint-paren"><p>${_("Use parentheses () to make expressions clear. You can use parentheses inside other parentheses.")}</p></li>
+      <li class="hint-item" id="hint-spaces"><p>${_("Do not use spaces in expressions.")}</p></li>
+      <li class="hint-item" id="hint-howto-constants"><p>${_("For constants, indicate multiplication explicitly (example: 5*c).")}</p></li>
+      <li class="hint-item" id="hint-howto-maffixes"><p>${_("For affixes, type the number and affix without a space (example: 5c).")}</p></li>
+      <li class="hint-item" id="hint-howto-functions"><p>${_("For functions, type the name of the function, then the expression in parentheses.")}</p></li>
+    </ul>
+  </li>
+
+  <li class="hint-item" id="hint-list">
+    <table class="calculator-input-help-table">
+      <tbody>
+        <tr>
+          <th scope="col">${_("To Use")}</th>
+          <th scope="col">${_("Type")}</th>
+          <th scope="col">${_("Examples")}</th>
+        </tr>
+        <tr>
+          <th scope="row">${_("Numbers")}</th>
+          <td>${_("Integers")}<br />
+            ${_("Fractions")}<br />
+            ${_("Decimals")}
+          </td>
+          <td>2520<br />
+            2/3<br />
+            3.14, .98
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">${_("Operators")}</th>
+          ## Translators: Please do not translate mathematical symbols.
+          <td>${_("+ - * / (add, subtract, multiply, divide)")}<br />
+            ## Translators: Please do not translate mathematical symbols.
+            ${_("^ (raise to a power)")}<br />
+            ## Translators: Please do not translate mathematical symbols.
+            ${_("_ (add a subscript)")}<br />
+            ## Translators: Please do not translate mathematical symbols.
+            ${_("|| (parallel resistors)")}
+          </td>
+          <td>x+(2*y)/x-1
+            x^(n+1)<br />
+            v_IN+v_OUT<br />
+            1||2
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">${_("Greek letters")}</th>
+          <td>${_("Name of letter")}</td>
+          <td>alpha<br />
+            lambda
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">${_("Constants")}</th>
+          <td>c, e, g, i, j, k, pi, q, T</td>
+          <td>20*c<br />
+            418*T
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">${_("Affixes")}</th>
+          <td>${_("Percent sign (%) and metric affixes (d, c, m, u, n, p, k, M, G, T)")}</td>
+          <td>20%<br />
+            20c<br />
+            418T
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">${_("Basic functions")}</th>
+          <td>abs, exp, fact or factorial, ln, log2, log10, sqrt</td>
+          <td>abs(x+y)<br />
+            sqrt(x^2-y)
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">${_("Trigonometric functions")}</th>
+          <td>sin, cos, tan, sec, csc, cot<br />
+            arcsin, sinh, arcsinh, etc.<br />
+          </td>
+          <td>sin(4x+y)<br />
+            arccsch(4x+y)
+          </td>
+          <td></td>
+        </tr>
+        <tr>
+          ## Translators: Please see http://en.wikipedia.org/wiki/Scientific_notation
+          <th scope="row">${_("Scientific notation")}</th>
+          ## Translators: 10^ is a mathematical symbol. Please do not translate.
+          <td>${_("10^ and the exponent")}</td>
+          <td>10^-9</td>
+        </tr>
+        <tr>
+          ## Translators: this is part of scientific notation. Please see http://en.wikipedia.org/wiki/Scientific_notation#E_notation
+          <th scope="row">${_("e notation")}</th>
+          ## Translators: 1e is a mathematical symbol. Please do not translate.
+          <td>${_("1e and the exponent")}</td>
+          <td>1e-9</td>
+        </tr>
+      </tbody>
+    </table>
+  </li>
+</ul>

--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -85,13 +85,6 @@ from django.core.urlresolvers import reverse
           </td>
         </tr>
         <tr>
-          <th scope="row">${_("Greek letters")}</th>
-          <td dir="auto">${_("Name of letter")}</td>
-          <td dir="auto">alpha<br />
-            lambda
-          </td>
-        </tr>
-        <tr>
           <th scope="row">${_("Constants")}</th>
           <td dir="auto">c, e, g, i, j, k, pi, q, T</td>
           <td dir="auto">20*c<br />


### PR DESCRIPTION
Solved three issues in the help popup of the calculator:

 - [Calculator: Improper pop-up hint displays (the page header is missing) moreover the page should be scrolled](https://app.asana.com/0/64330652734141/59288979744630)
 - [Calculator: Invalid syntax is displayed when entering "Greek letters"](https://app.asana.com/0/64330652734141/59391052429500)
 - [Calculator: The Hint Popup displayed improperly under Android OS, Default browser](https://app.asana.com/0/64330652734141/59391052429507).
 - [Corrected the direction of the English equations](https://app.asana.com/0/64330652734141/59391052429458)

Didn't test it on IE yet, ~~will test it soon inshaAllah.~~ I need a proper workstation or a browserstack.com account to do so!
