### PR TITLE
Fixed the untranslatable (add a subscript) in the calculator

### DIFF
--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -64,8 +64,11 @@ from django.core.urlresolvers import reverse
                     <td>${_("+ - * / (add, subtract, multiply, divide)")}<br />
                       ## Translators: Please do not translate mathematical symbols.
                       ${_("^ (raise to a power)")}<br />
-                      ## Translators: Please do not translate mathematical symbols.
-                      ${_("_ (add a subscript)")}<br />
+
+                      ## Developers: Please keep the space at the begining of the string, otherwise gettext will ignore it
+                      ## Translators: Please do not translate mathematical symbols, Edraak-specific
+                      ${_(" _ (add a subscript)")}<br />
+
                       ## Translators: Please do not translate mathematical symbols.
                       ${_("|| (parallel resistors)")}
                     </td>


### PR DESCRIPTION
Task:

 - [Under Calculator hint popup , the "add a subscript" sentence should translate moreover the parentheses is displayed improperly ](https://app.asana.com/0/64330652734141/59391052429458)