### PR TITLE
Fixup: draggable capa icons disappear in RTL layout

### DIFF
--- a/common/static/js/capa/drag_and_drop/draggables.js
+++ b/common/static/js/capa/drag_and_drop/draggables.js
@@ -175,8 +175,7 @@ define(['js/capa/drag_and_drop/draggable_events', 'js/capa/drag_and_drop/draggab
                 'style=" ' +
                     'width: 100px; ' +
                     'height: 100px; ' +
-                    'display: inline; ' +
-                    'float: left; ' +
+                    'display: inline-block; ' +
                     'overflow: hidden; ' +
                     'border-left: 1px solid #CCC; ' +
                     'border-right: 1px solid #CCC; ' +


### PR DESCRIPTION
 - Task: [Issue in Draggable problems](https://app.asana.com/0/13296136706033/75365883578991)

