### PR TITLE
Fix bayt 500 error, translations and URL error

### DIFF
--- a/conf/locale/babel_mako.cfg
+++ b/conf/locale/babel_mako.cfg
@@ -1,15 +1,24 @@
 # Extraction from Mako templates
 [mako: cms/templates/**.html]
 input_encoding = utf-8
+
 [mako: lms/templates/**.html]
 input_encoding = utf-8
+
 [mako: lms/templates/**.mustache]
 input_encoding = utf-8
+
 [mako: common/templates/**.html]
 input_encoding = utf-8
+
 [mako: cms/templates/emails/**.txt]
 input_encoding = utf-8
+
 [mako: lms/templates/emails/**.txt]
 input_encoding = utf-8
+
 [mako: lms/templates/registration/**.txt]
+input_encoding = utf-8
+
+[mako: lms/templates/bayt/**.txt]
 input_encoding = utf-8

--- a/lms/djangoapps/edraak_bayt/urls.py
+++ b/lms/djangoapps/edraak_bayt/urls.py
@@ -1,9 +1,21 @@
-from django.conf import settings
 from django.conf.urls import patterns, url
-from django.core.urlresolvers import LocaleRegexURLResolver
+from django.conf import settings
 
 
 urlpatterns = patterns('',
-        url(r'^get_student_email_for_bayt$', 'edraak_bayt.views.get_student_email', name="edraak_bayt_get_student_email"),
-        url(r'^bayt-activation$', 'edraak_bayt.views.activation', name="bayt_activation"),
+    url(
+        r'^get_student_email_for_bayt$',
+        'edraak_bayt.views.get_student_email',
+        name='edraak_bayt_get_student_email',
+    ),
+    url(
+        r'^bayt-activation$',
+        'edraak_bayt.views.activation',
+        name='bayt_activation',
+    ),
+    url(
+        r'^bayt/check-email/{}/(?P<email>.*)$'.format(settings.COURSE_ID_PATTERN),
+        'edraak_bayt.views.check_email',
+        name='bayt_check_email',
+    ),
 )

--- a/lms/djangoapps/edraak_bayt/views.py
+++ b/lms/djangoapps/edraak_bayt/views.py
@@ -1,19 +1,26 @@
 import hashlib
 import urllib
 import simplejson
+from httplib2 import Http
+import logging
+
+
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.mail import send_mail
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 from django.contrib.auth.decorators import login_required
-from httplib2 import Http
-import logging
+from django.core.urlresolvers import reverse
+
+from opaque_keys.edx.keys import CourseKey
+from xmodule.modulestore.django import modulestore
 
 from edraak_misc.utils import validate_email, get_absolute_url_prefix
 
 from edxmako.shortcuts import render_to_response, render_to_string
 from util.json_request import JsonResponse
+
 from .models import BaytPublishedCertificate
 
 log = logging.getLogger(__name__)
@@ -29,37 +36,46 @@ def get_student_email(request):
     user_id = request.user.id
 
     if not validate_email(user_email):
-        return JsonResponse({"success": False, "error": _('Invalid Email')})
+        return JsonResponse({'success': False, 'error': _('Invalid Email')})
 
     try:
         user = User.objects.get(id=user_id)
     except User.DoesNotExist:
         ## close the pop-up because there is sth wrong
-        return JsonResponse({"success": False, "error": 'Invalid ID'})
+        return JsonResponse({'success': False, 'error': 'Invalid ID'})
 
     if user.email == user_email:
         h = Http()
-        param = {
+        params = {
             'secret_key': settings.BAYT_SECRET_KEY,
             'valid_until': cert_end,
             'certificate_name': course_name.encode('UTF-8'),
             'email_address': user_email
         }
 
-        url = "https://api.bayt.com/api/edraak-api/post.adp?" + urllib.urlencode(param)
+        url = 'https://api.bayt.com/api/edraak-api/post.adp?' + urllib.urlencode(params)
         resp, content = h.request(url)
         json_content = simplejson.loads(content)
 
-        if json_content['status'] == "NOT EXISTS":
-            return JsonResponse({"success": True, "error": False, "redirect_to": True, "response": content})
+        if json_content['status'] == 'NOT EXISTS':
+            return JsonResponse({
+                'success': True,
+                'error': False,
+                'redirect_to': '{bayt_base}{register}'.format(
+                    bayt_base=settings.BAYT_BASE,
+                    register='/en/register-j/',
+                ),
+                'response': content,
+            })
         else:
             BaytPublishedCertificate.objects.create(user_id=int(user_id), course_id=course_id)
-            return JsonResponse({"success": True, "error": False, "redirect_to": False, "response": content})
+            return JsonResponse({'success': True, 'error': False, 'redirect_to': False, 'response': content})
     else:
         secret_key = settings.BAYT_SECRET_KEY
         my_string = user_email + course_name + secret_key
         access_token = hashlib.md5(my_string.encode('UTF-8')).hexdigest()
-        param = {
+
+        params = {
             'email': user_email,
             'course_name': course_name.encode('UTF-8'),
             'access_token': access_token,
@@ -69,18 +85,45 @@ def get_student_email(request):
         }
 
         message = render_to_string('bayt/verification_email.txt', {
-            'activation_url': get_absolute_url_prefix(request) + "/bayt-activation?" + urllib.urlencode(param)
+            'activation_url': '{base}{view}?{params}'.format(
+                base=get_absolute_url_prefix(request),
+                view=reverse('bayt_activation'),
+                params=urllib.urlencode(params)
+            ),
         })
 
         try:
-            subject = _('Verify your email to share your Edraak certificate on Baytq')
+            subject = _('Verify your email to share your Edraak certificate on Bayt.com')
             send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, [user_email], fail_silently=False)
             # here we have to send an auth email to user email that contains a link to
             # get back to here and then post the certificate
-            return JsonResponse({"success": True, "error": False, "redirect_to": False})
+            return JsonResponse({
+                'success': True,
+                'error': False,
+                'redirect_to': reverse('bayt_check_email', kwargs={
+                    'email': user_email,
+                    'course_id': course_id,
+                }),
+            })
         except:
             log.warning('Unable to send activation email to user', exc_info=True)
-            return JsonResponse({"success": False, "error": True, "redirect_to": False})
+            return JsonResponse({
+                'success': False,
+                'error': True,
+                'redirect_to': False,
+            })
+
+
+@login_required
+def check_email(request, course_id, email):
+    course_key = CourseKey.from_string(course_id)
+    course = modulestore().get_course(course_key)
+
+    return render_to_response('bayt/check_email.html', {
+        'course': course,
+        'email': email,
+    })
+
 
 @login_required
 def activation(request):
@@ -95,27 +138,42 @@ def activation(request):
     current_access_token = hashlib.md5(my_string.encode('UTF-8')).hexdigest()
 
     if current_access_token == access_token:
-        h = Http()
-        param = {
-            'secret_key': settings.BAYT_SECRET_KEY,
-            'valid_until': cert_end,
-            'certificate_name': course_name.encode('UTF-8'),
-            'email_address': user_email
-        }
-        url = "https://api.bayt.com/api/edraak-api/post.adp?" + urllib.urlencode(param)
-        resp, content = h.request(url)
+        connection = Http()
+
+        resp, content = connection.request('{base}?{params}'.format(
+            base='https://api.bayt.com/api/edraak-api/post.adp',
+            params=urllib.urlencode({
+                'secret_key': settings.BAYT_SECRET_KEY,
+                'valid_until': cert_end,
+                'certificate_name': course_name.encode('UTF-8'),
+                'email_address': user_email
+            }),
+        ))
 
         json_content = simplejson.loads(content)
 
-        if json_content['status'] == "NOT EXISTS":
+        if json_content['status'] == 'NOT EXISTS':
             # redirect user to bayt registration
-            return render_to_response("bayt/callback.html", {"status": False})
+            return render_to_response('bayt/callback.html', {
+                'status': False,
+                'redirect_url': '{bayt_base}{register}'.format(
+                    bayt_base=settings.BAYT_BASE,
+                    register='/en/register-j/',
+                )
+            })
+
         BaytPublishedCertificate.objects.create(user_id=user_id, course_id=course_id)
-        return render_to_response("bayt/callback.html", {"status": True})
+        return render_to_response('bayt/callback.html', {
+            'status': True,
+            'redirect_url': '{base}{view}'.format(
+                base=get_absolute_url_prefix(request),
+                view=reverse('dashboard'),
+            ),
+        })
     else:
         log.warning(
-            "Access tokens don't match: current='%s' original='%s'",
+            'Access tokens don\'t match: current=\'%s\' original=\'%s\'',
             current_access_token,
             access_token,
         )
-        return JsonResponse({"success": False, "error": True, "redirect_to": False})
+        return JsonResponse({'success': False, 'error': True, 'redirect_to': False})

--- a/lms/templates/bayt/callback.html
+++ b/lms/templates/bayt/callback.html
@@ -2,33 +2,41 @@
 
 <%inherit file="../main.html" />
 
+<%block headextra>
+  % if status:
+    <meta http-equiv="refresh" content="5; url=${redirect_url}" />
+  % endif
+</%block>
+
 <section class="container activation">
   <section class="message">
-    <h1>${_("Bayt Activation")}</h1>
-    <hr class="horizontal-divider">
+    <h1>
+      % if status:
+        ${_("Bayt.com Account Activation")}
+      % else:
+        ${_("Bayt.com Account not Found")}
+      % endif
+    </h1>
+
+      <hr class="horizontal-divider">
       % if status:
         <p>
           ${_("Your certificate has been posted to Bayt successfully. "
               "You well redirect to Edraak in 5 seconds. "
               "If not click {link_start}here{link_end}").format(
-                 link_start='<a href="{}">'.format(settings.SITE_NAME),
+                 link_start='<a href="{}">'.format(redirect_url),
                  link_end='</a>',
           )}
         </p>
       % else:
         <p>
-          ${_("Please click {link_start}here{link_end}").format(
-                 link_start='<a href="{}/en/register-j/">'.format(settings.BAYT_BASE),
+          ${_("You don't have a Bayt.com with the email you've entered yet. "
+              "To register a new Bayt.com account, please click {link_start}here{link_end}.").format(
+                 link_start='<a href="{}">'.format(redirect_url),
                  link_end='</a>',
           )}
         </p>
       % endif
   </section>
 </section>
-<script>
-        % if status:
-            setTimeout("window.location='${settings.SITE_NAME}'", 5000);
-        % else:
-            setTimeout("window.location='${settings.BAYT_BASE}/en/register-j/'", 500);
-        % endif
-</script>
+

--- a/lms/templates/bayt/check_email.html
+++ b/lms/templates/bayt/check_email.html
@@ -1,0 +1,17 @@
+<%! from django.utils.translation import ugettext as _ %>
+
+<%inherit file="../main.html" />
+
+<section class="container activation">
+    <section class="message">
+        <h1>${_("Verification Email has been Sent")}</h1>
+        <hr class="horizontal-divider">
+        <p>
+            ${_("Your verification email has been sent. "
+                "Please check your email's inbox (and sometimes spam) for the address '{email}', "
+                "and click the activation link.").format(
+                     email=email,
+            )}
+        </p>
+    </section>
+</section>

--- a/lms/templates/bayt/verification_email.txt
+++ b/lms/templates/bayt/verification_email.txt
@@ -1,15 +1,9 @@
-<%namespace file="../main.html" import="stanford_theme_enabled" />
 <%! from django.utils.translation import ugettext as _ %>
-<%! import urllib %>
 
 ${_("Thank you for posting your certificate on Bayt.com \n"
     "To proceed in process please click on the link below")}
 
-% if is_secure:
-https://${encoded_url}
-% else:
-http://${encoded_url}
-% endif
+${activation_url}
 
 ${_("If you didn't request this, you don't need to do anything; you won't "
     "receive any more email from us. Please do not reply to this e-mail; "

--- a/lms/templates/edraak_certificates/view.html
+++ b/lms/templates/edraak_certificates/view.html
@@ -83,7 +83,7 @@
             }, function (data) {
                 if (data.success) {
                     if (data.redirect_to) {
-                        window.location.replace("${settings.BAYT_BASE}/en/register-j/");
+                        window.location.replace(data.redirect_to);
                     } else {
                         $(".close-modal").click();
                         location.reload();


### PR DESCRIPTION
Task:
  
  - ["Error 500"  page is displayed when the user clicks on verification link in the "Edraak Bayt verification" email](https://app.asana.com/0/65444854149008/65966205208569)

 

This used to happen only when a student has different emails on Bayt and Edraak.

Note: A student can post a certificate to Bayt on an account that it's
      email not necessarily the same is his email on Edraak.