### PR TITLE
Removed duplicates from both edraak-customized.po files

### DIFF
--- a/pavelib/edraak.py
+++ b/pavelib/edraak.py
@@ -89,6 +89,23 @@ def i18n_po_pull_edraak():
         sh(cmd)
 
 
+def i18n_remove_duplicates(pofile):
+    """
+    Removes duplicates from a POFile list, i.e. make it unique!
+
+    This reduces the load on the JavaScript djangojs.mo and makes
+    the pavelib/edraak.py process more solid and explicit.
+    """
+
+    existing_strings = {}
+
+    for entry in reversed(pofile):
+        if entry.msgid not in existing_strings:
+            existing_strings[entry.msgid] = True
+        else:
+            pofile.remove(entry)
+
+
 @task
 @js_nonjs
 def i18n_edraak_generate_files(is_js, suffix):
@@ -112,6 +129,7 @@ def i18n_edraak_generate_files(is_js, suffix):
 
         # Save a backup in git for later inspection,
         # and keep django.po untouched
+        i18n_remove_duplicates(django_pofile)
         django_pofile.save('django{}-edraak-customized.po'.format(suffix))
         django_pofile.save_as_mofile('django{}.mo'.format(suffix))
 


### PR DESCRIPTION
Reopening #119 on master.

----

Task: [i18n_edraak_pull does not pull some strings](https://app.asana.com/0/13296136706033/59427788208963)

 - Check PR #120 to see the changes in `po` files. Mainly massive deletions of duplicate (i.e. unwanted strings).

There could be side effects of this but I haven't seen any.

