### PR TITLE
Dashboard untranslated strings

### DIFF
--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -177,6 +177,7 @@ from django.core.urlresolvers import reverse
     <section class="user-info">
       <ul>
         <li class="heads-up">
+          ## Translators: Missing from Transifex, so marking it as Edraak-specific to override
           <span class="title">${_("Want to change your account settings?")}</span>
 
           <span class="copy">${_("Click on your username above.")}</span>

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -201,11 +201,13 @@ from student.helpers import (
                       ## Translators: The course's name will be added to the end of this sentence.
                       % if not is_course_blocked:
                       <a href="#unenroll-modal" class="action action-unenroll" rel="leanModal" data-course-id="${course.id | h}" data-course-number="${course.number | h}" data-dashboard-index="${dashboard_index}"
+                         ## Translators: Missing from Transifex, so marking it as Edraak-specific to override
                          onclick="set_unenroll_message('${_("Are you sure you want to unenroll from %(course_number)s?")}', '')">
                         ${_('Unenroll')}
                       </a>
                       % else:
                       <a class="action action-unenroll is-disabled" data-course-id="${course.id | h}" data-course-number="${course.number | h}" data-dashboard-index="${dashboard_index}"
+                         ## Translators: Missing from Transifex, so marking it as Edraak-specific to override
                          onclick="set_unenroll_message('${_("Are you sure you want to unenroll from %(course_number)s?")}', '')">
                         ${_('Unenroll')}
                       </a>

--- a/pavelib/edraak.py
+++ b/pavelib/edraak.py
@@ -308,7 +308,10 @@ def i18n_edraak_push(is_js, suffix):
             pofile = polib.pofile(po_path)
 
             for entry in pofile:
-                if entry not in edx_pofile:
+                new_entry = entry not in edx_pofile
+                marked_as_specific = 'edraak-specific' in entry.comment.lower()
+
+                if new_entry or marked_as_specific:
                     edraak_specific.append(entry)
 
         edraak_specific.save(edraak_specific_path)


### PR DESCRIPTION
Got back the Edraak-specific comment, marked some missing (from Transifex) dashboard strings as Edraak-specific.

**Tasks:**

  - [Dashboard/Ar. interface: The unenroll message is displaying in English](https://app.asana.com/0/46037300235132/68061413396614)
  - [Dashboard: The "Want to change your account settings" should be translated ](https://app.asana.com/0/23241728739082/90256955691385)