### PR TITLE
Show hidden courses in /v1/courses API

### DIFF
--- a/lms/djangoapps/edraak_api/urls.py
+++ b/lms/djangoapps/edraak_api/urls.py
@@ -2,5 +2,6 @@ from django.conf.urls import patterns, url
 
 urlpatterns = patterns(
     'edraak_api.views',
-    url(r'^courses/$', 'courses'),
+    url(r'^courses/$', 'courses', kwargs={'show_hidden': False}),
+    url(r'^courses/with_hidden/$', 'courses', kwargs={'show_hidden': True}),
 )

--- a/lms/djangoapps/edraak_api/views.py
+++ b/lms/djangoapps/edraak_api/views.py
@@ -1,6 +1,8 @@
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import AnonymousUser
 
+from django.conf import settings
+
 from util.json_request import JsonResponse
 from courseware.courses import (
     get_courses,
@@ -8,6 +10,9 @@ from courseware.courses import (
     course_image_url,
     get_course_about_section,
 )
+
+import branding
+from courseware.access import has_access
 
 from edraak_misc.utils import edraak_courses_logic, get_absolute_url_prefix
 
@@ -27,26 +32,43 @@ def _get_course_status(course):
         return 'hidden'
 
 
-def courses(request):
+def courses(request, show_hidden):
     """
     Renders the courses list for the API.
+
+    :param request: The django HttpRequest object.
+    :param show_hidden: True or False, (controlled from the urls.py file) to show courses with
+                        upcoming enrollment date.
+
+    :return: JsonResponse with a list of the courses.
     """
+    courses_list = branding.get_visible_courses()
 
-    # Hardcoded `AnonymousUser()` to hide unpublished courses always
-    courses = get_courses(AnonymousUser())
-    courses = sort_by_announcement(courses)
-    courses = edraak_courses_logic(courses)
+    if not show_hidden:
+        # Using `AnonymousUser()` to hide unpublished courses
+        anonymous_user = AnonymousUser()
 
+        # The logic bellow has been copied (with amendments) from `courseware.courses.get_courses`,
+        # Just in case something changes with edX releases.
+        permission_name = settings.COURSE_CATALOG_VISIBILITY_PERMISSION
 
-    courses_json = []
+        courses_list = [
+            c for c in courses_list
+            if has_access(anonymous_user, permission_name, c)
+        ]
+
+    courses_list = sort_by_announcement(courses_list)
+    courses_list = edraak_courses_logic(courses_list)
+
+    courses_json_list = []
 
     prefix = get_absolute_url_prefix(request)
 
-    for course in courses:
+    for course in courses_list:
         video_tag = get_course_about_section(course, "video")
         youtube_id = video_tag[video_tag.find("embed") + 6:video_tag.find("?")]
 
-        courses_json.append({
+        courses_json_list.append({
             "id": unicode(course.id),
             "number": course.display_number_with_default,
             "name": course.display_name_with_default,
@@ -64,4 +86,4 @@ def courses(request):
             "effort": get_course_about_section(course, "effort").strip(),
         })
 
-    return JsonResponse(courses_json)
+    return JsonResponse(courses_json_list)


### PR DESCRIPTION
**Summary:**
 - Added an API endpoint /v1/courses/with_hidden/ to list all courses including hidden ones!

-------

Although this is technically independent. But it has been made for this marketing site pull request:

 - [Remove the add button from courses admin so the others have to use the `/update-course/` URL](https://bitbucket.org/Edraak/marketing-site/pull-requests/221/wip-remove-the-add-button-from-courses/diff)