### PR TITLE
Fixed an error for users with Arabic usernames when changing the SECRET_KEY

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -144,7 +144,7 @@ def anonymous_id_for_user(user, course_id, save=True):
             log.error(
                 u"Stored anonymous user id %r for user %r "
                 u"in course %r doesn't match computed id %r",
-                user,
+                unicode(user),
                 course_id,
                 anonymous_user_id.anonymous_user_id,
                 digest


### PR DESCRIPTION
**Note:**
  - This *seems* to happen only for servers WITHOUT `LC_ALL=en_US.UTF-8`, nevermind!

Task:
  - [One of our learners try to issue the certificate for some courses ,but an error 500 page is displayed](https://app.asana.com/0/23241728739082/108976671959866)

