### PR TITLE
Allow editing users with unicode usernames

### DIFF
--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -2,8 +2,7 @@
 from django import forms
 from django.contrib.auth.models import User
 from ratelimitbackend import admin
-from edraak_validation import UnicodeUserAdmin
-from django.contrib.auth.models import User
+from django.contrib.auth.admin import UserAdmin
 
 from xmodule.modulestore.django import modulestore
 from opaque_keys import InvalidKeyError
@@ -166,6 +165,16 @@ class UserProfileAdmin(admin.ModelAdmin): #SYNCTODO: check omar's https://github
         model = UserProfile
 
 
+class UnicodeFriendlyUserAdmin(UserAdmin):
+    """
+    Allows editing the users while skipping the username check, so we can have Unicode username with no problems.
+    """
+    def get_readonly_fields(self, *args, **kwargs):
+        return super(UserAdmin, self).get_readonly_fields(*args, **kwargs) + (
+            'username',
+        )
+
+
 admin.site.register(UserTestGroup)
 
 admin.site.register(CourseEnrollmentAllowed)
@@ -184,5 +193,4 @@ admin.site.register(CourseEnrollment, CourseEnrollmentAdmin)
 
 admin.site.register(UserProfile, UserProfileAdmin)
 
-# Edraak: Support Unicode in admin/user pages
-admin.site.register(User, UnicodeUserAdmin)
+admin.site.register(User, UnicodeFriendlyUserAdmin)

--- a/common/djangoapps/student/edraak_validation.py
+++ b/common/djangoapps/student/edraak_validation.py
@@ -1,11 +1,8 @@
 """
 Allow Unicode in Admin and LMS.
 """
-from django.contrib.auth.admin import UserAdmin
 from django import forms
-from ratelimitbackend import admin
 import re
-from django.contrib.auth.forms import UserCreationForm, UserChangeForm
 from django.core.validators import RegexValidator
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
@@ -21,19 +18,6 @@ unicode_username_field = forms.RegexField(label=_("Username"),
                                               'invalid': _("This value may contain only letters, numbers and"
                                                            " @/./+/-/_ characters.")
                                           })
-
-
-class UnicodeUserCreationForm(UserCreationForm):
-    username = unicode_username_field
-
-
-class UnicodeUserChangeForm(UserChangeForm):
-    username = unicode_username_field
-
-
-class UnicodeUserAdmin(UserAdmin):
-    form = UnicodeUserChangeForm
-    add_form = UnicodeUserCreationForm
 
 
 validate_username = RegexValidator(


### PR DESCRIPTION
Basically, just make the `username` readonly and that's it:

 - Task: [Admin panel /users :validation message is displayed for the  Arabic "Username"](https://app.asana.com/0/96288420553298/112085688076772)