### PR TITLE
Supporting Arabic users in mobile API

### DIFF
--- a/common/djangoapps/enrollment/urls.py
+++ b/common/djangoapps/enrollment/urls.py
@@ -11,7 +11,7 @@ from .views import (
     EnrollmentCourseDetailView
 )
 
-USERNAME_PATTERN = '(?P<username>[\w.@+-]+)'
+USERNAME_PATTERN = settings.USERNAME_PATTERN
 
 urlpatterns = patterns(
     'enrollment.views',

--- a/lms/djangoapps/mobile_api/users/urls.py
+++ b/lms/djangoapps/mobile_api/users/urls.py
@@ -6,7 +6,7 @@ from django.conf import settings
 
 from .views import UserDetail, UserCourseEnrollmentsList, UserCourseStatus
 
-USERNAME_PATTERN = r'(?P<username>[\w.+-]+)'
+USERNAME_PATTERN = settings.USERNAME_PATTERN
 
 urlpatterns = patterns(
     'mobile_api.users.views',


### PR DESCRIPTION
The problem was that all arabic usernames couldn't login nor view courses in the app.