### PR TITLE
Reopen: Prevent double `atomic` database locks, so the users can grade

### DIFF
--- a/lms/djangoapps/edraak_certificates/views.py
+++ b/lms/djangoapps/edraak_certificates/views.py
@@ -10,6 +10,7 @@ from django.core.urlresolvers import reverse
 from django.core.servers.basehttp import FileWrapper
 from django.core.files.temp import NamedTemporaryFile
 from django.contrib.auth.decorators import login_required
+from django.db import transaction
 
 from dateutil.relativedelta import relativedelta
 from edxmako.shortcuts import render_to_response
@@ -30,6 +31,7 @@ def issue(request, course_id):
     })
 
 
+@transaction.non_atomic_requests
 @login_required
 def view(request, course_id):
     user = request.user
@@ -52,6 +54,7 @@ def view(request, course_id):
     })
 
 
+@transaction.non_atomic_requests
 @login_required
 def download(request, course_id):
     user = request.user
@@ -71,6 +74,7 @@ def download(request, course_id):
         return redirect(reverse('dashboard'))
 
 
+@transaction.non_atomic_requests
 @login_required
 def preview(request, course_id):
     user = request.user

--- a/lms/djangoapps/edraak_misc/views.py
+++ b/lms/djangoapps/edraak_misc/views.py
@@ -1,13 +1,20 @@
 from django.views.decorators.csrf import ensure_csrf_cookie
+from django.conf import settings
+from django.db import transaction
+from django.contrib.auth.decorators import login_required
+from django.contrib.auth.models import AnonymousUser
+
+from edxmako.shortcuts import render_to_response
+
 from util.json_request import JsonResponse
 from util.cache import cache_if_anonymous
-from django.conf import settings
+
 from courseware.courses import get_courses, sort_by_announcement
-from edxmako.shortcuts import render_to_response
-from django.contrib.auth.models import AnonymousUser
 from .utils import is_student_pass, edraak_courses_logic
 
 
+@transaction.non_atomic_requests
+@login_required
 def check_student_grades(request):
     user = request.user
     course_id = request.POST['course_id']


### PR DESCRIPTION
Reopening the missed changes in #168  

--------------
Original Description:

 - See: https://openedx.atlassian.net/browse/TNL-3703

Tasks:

 - View the Certificate: https://app.asana.com/0/96288420553298/111493082538475
 - Download as PDF: https://app.asana.com/0/96288420553298/111493082538465