### PR TITLE
Changing default enrollment to Honor instead of Audit

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -100,8 +100,8 @@ class CourseMode(models.Model):
     NO_ID_PROFESSIONAL_MODE = "no-id-professional"
     CREDIT_MODE = "credit"
 
-    DEFAULT_MODE = Mode(AUDIT, _('Audit'), 0, '', 'usd', None, None, None)
-    DEFAULT_MODE_SLUG = AUDIT
+    DEFAULT_MODE = Mode(HONOR, _('Honor'), 0, '', 'usd', None, None, None)
+    DEFAULT_MODE_SLUG = HONOR
 
     # Modes that allow a student to pursue a verified certificate
     VERIFIED_MODES = [VERIFIED, PROFESSIONAL]


### PR DESCRIPTION
Fixes: [Enrollment: Server error page is displayed when clicking on "Enroll" button under course about page](https://app.asana.com/0/inbox/35717934599876/111785934393433/137466755082950)

I just changed the default enrollment mode to Honor instead of audit.