### PR TITLE
Removing messages.po as it's deprecated

### DIFF
--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -149,7 +149,6 @@ generate_merge:
         - django-studio.po
         - mako.po
         - mako-studio.po
-        - messages.po
         - wiki.po
     djangojs.po:
         - djangojs-partial.po


### PR DESCRIPTION
No task.
This file prevents us pushing translations to transfix as it's no longer available.