### PR TITLE
Course info calendar icon RTL fix

### DIFF
--- a/lms/static/sass/course/_info.scss
+++ b/lms/static/sass/course/_info.scss
@@ -33,8 +33,16 @@ div.info-wrapper {
         h2 {
           font-size: $body-font-size;
           font-weight: bold;
-          background: url('#{$static-path}/images/calendar-icon.png') 0 center no-repeat;
-          padding-left: $baseline;
+          @include padding-left($baseline);
+          background: url('#{$static-path}/images/calendar-icon.png') no-repeat;
+
+          @include ltr {
+            background-position: left center;
+          }
+
+          @include rtl {
+            background-position: right center;
+          }
         }
 
         section.update-description {


### PR DESCRIPTION
Task: [LMS/Course Info page: for Arabic interface ,the "Calendar" icon displays to the left instead to the right](https://app.asana.com/0/96288420553298/140822648914672)
