### PR TITLE
Hotfix: Remove English forum entries from Solar Energy course part 2, one more time.

### DIFF
--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -81,7 +81,7 @@ def hack_remove_unwanted_modules(course, categories):
     import re
     SOLAR_ENERGY_COURSES = [u'ET.3034TU', u'SE-Pt2']
 
-    if course.id.course in SOLAR_ENERGY_COURSES:
+    if course.id.course not in SOLAR_ENERGY_COURSES:
         return categories
 
     def has_english_text(text):


### PR DESCRIPTION
Task:

 - [Introduction to Solar Energy Cells – Part 2: the discussion topics are displayed twice (in English and in Arabic) under the discussion module](https://app.asana.com/0/23241728739082/148325070732749)

This fixes a bug in #188 

Reference: 

 - This adds up to the previous hotfix: https://github.com/Edraak/edx-platform/pull/112
