### PR TITLE
Add loading status to the course rerun button

### DIFF
--- a/cms/static/js/index.js
+++ b/cms/static/js/index.js
@@ -59,11 +59,16 @@ define(["domReady", "jquery", "underscore", "js/utils/cancel_on_escape", "js/vie
                 run: run
             };
 
+            // Go into course creating state
+            $('.new-course-save').addClass('is-disabled').attr('aria-disabled', true).addClass('is-processing').html(
+               '<i class="icon fa fa-refresh fa-spin"></i> ' + gettext('Creating a new course')
+            );
+
             analytics.track('Created a Course', course_info);
             CreateCourseUtils.create(course_info, function (errorMessage) {
                 $('.create-course .wrap-error').addClass('is-shown');
                 $('#course_creation_error').html('<p>' + errorMessage + '</p>');
-                $('.new-course-save').addClass('is-disabled').attr('aria-disabled', true);
+                $('.new-course-save').removeClass('is-processing').text('Create');
             });
         };
 

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -108,7 +108,7 @@
 
           <div class="actions">
             <input type="hidden" value="${allow_unicode_course_id}" class="allow-unicode-course-id" />
-            <input type="submit" value="${_('Create')}" class="action action-primary new-course-save" />
+            <button type="submit" class="action action-primary new-course-save">${_('Create')}</button>
             <input type="button" value="${_('Cancel')}" class="action action-secondary action-cancel new-course-cancel" />
           </div>
         </form>


### PR DESCRIPTION
This way the course rerun button cannot be clicked twice.

Task:

 - [Create Course:When clicking on "Create " button , there is no action happens and the course is created and listed under the studio courses list](https://app.asana.com/0/96288420553298/111785934393473)