### PR TITLE
Hack to show the save button on small screens for the TinyMCE editor

### DIFF
--- a/cms/static/sass/_shame.scss
+++ b/cms/static/sass/_shame.scss
@@ -139,6 +139,21 @@ div.wrapper-comp-editor.is-inactive ~ div.launch-latex-compiler{
   }
 }
 
+
+// ====================
+
+// Tiny MCE editor
+// I made this hack that fixes the problem, because I couldn't fix it in a better way.
+// Author: Omar Al-Ithawi
+.mce-window {
+  @media (max-height: 630px) {
+    // Small screens only.
+    @include transform(scale(0.85));
+    @include transform-origin(top);
+  }
+}
+
+
 // ====================
 
 // TODOs:


### PR DESCRIPTION
Task: 

 - [Studio/HTML Component: The HTML source code editor page does not scroll down so that you will not be able to save the changes that you have made on the HTML code](https://app.asana.com/0/96288420553298/96288420553298)