### PR TITLE
Handle social login timeouts

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1490,6 +1490,11 @@ def create_account_with_params(request, params):
 
     if should_link_with_social_auth or (third_party_auth.is_enabled() and pipeline.running(request)):
         params["password"] = pipeline.make_random_password()
+    elif params["is_third_party_auth"]:
+        # Hack by Edraak to detect timed-out social login attempts.
+        raise ValidationError({
+            "password": _("Registration process has timed out. Please refresh the page and start over.")
+        }, code=400)
 
     # if doing signup for an external authorization, then get email, password, name from the eamap
     # don't use the ones from the form, since the user could have hacked those

--- a/openedx/core/djangoapps/user_api/helpers.py
+++ b/openedx/core/djangoapps/user_api/helpers.py
@@ -113,7 +113,7 @@ class InvalidFieldError(Exception):
 class FormDescription(object):
     """Generate a JSON representation of a form. """
 
-    ALLOWED_TYPES = ["text", "email", "select", "textarea", "checkbox", "password"]
+    ALLOWED_TYPES = ["text", "email", "select", "textarea", "checkbox", "password", "hidden"]
 
     ALLOWED_RESTRICTIONS = {
         "text": ["min_length", "max_length"],

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -165,7 +165,7 @@ class LoginSessionView(APIView):
 class RegistrationView(APIView):
     """HTTP end-points for creating a new user. """
 
-    DEFAULT_FIELDS = ["email", "name", "username", "password"]
+    DEFAULT_FIELDS = ["email", "name", "username", "password", "is_third_party_auth"]
 
     EXTRA_FIELDS = [
         "city",
@@ -355,6 +355,29 @@ class RegistrationView(APIView):
             error_messages={
                 "required": error_msg
             }
+        )
+
+    def _add_is_third_party_auth_field(self, form_desc, required):
+        """
+        Add the hidden third party auth indicator.
+
+        This field is used to detect timed-out social login attempts.
+
+        Arguments:
+            form_desc: A form description
+
+        Keyword Arguments:
+            required (bool): Whether this field is required.
+            * This value is actually ignored, but needed to comply with the caller expected signature.
+
+        """
+
+        form_desc.add_field(
+            "is_third_party_auth",
+            label="",
+            field_type="hidden",
+            default="",
+            required=False,
         )
 
     def _add_name_field(self, form_desc, required=True):
@@ -774,6 +797,12 @@ class RegistrationView(APIView):
                         instructions="",
                         restrictions={}
                     )
+
+                    form_desc.override_field_properties(
+                        "is_third_party_auth",
+                        default="true",
+                    )
+
 
 
 class PasswordResetView(APIView):


### PR DESCRIPTION
Example: login using Facebook but wait more than 10 minute to complete the registration form.

Task:

 - [Login: The "يجب ادخال كلمة السر الصحيحة" error message is displayed upon login using Facebook account , then wait for 10 mins. before submitting the registration form](https://app.asana.com/0/96288420553298/65120614458349)