### PR TITLE
Fix bug with discussion response "More..." actions

### DIFF
--- a/common/static/coffee/spec/discussion/view/discussion_view_spec_helper.coffee
+++ b/common/static/coffee/spec/discussion/view/discussion_view_spec_helper.coffee
@@ -14,6 +14,12 @@ class @DiscussionViewSpecHelper
           body: "",
           title: "dummy title",
           created_at: "2014-08-18T01:02:03Z"
+          ability: {
+              can_delete: false,
+              can_reply: true,
+              can_vote: false,
+              editable: false,
+            }
         }
         $.extend(thread, props)
 
@@ -72,7 +78,7 @@ class @DiscussionViewSpecHelper
         spy.reset()
         button.trigger($.Event("keydown", {which: 32}))
         expect(spy).toHaveBeenCalled()
-        
+
     @checkVoteButtonEvents = (view) ->
         @checkButtonEvents(view, "toggleVote", ".action-vote")
 

--- a/common/static/coffee/src/discussion/views/discussion_content_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_content_view.coffee
@@ -1,12 +1,12 @@
 if Backbone?
   class @DiscussionContentView extends Backbone.View
 
-  
+
     events:
       "click .discussion-flag-abuse": "toggleFlagAbuse"
       "keydown .discussion-flag-abuse":
         (event) -> DiscussionUtil.activateOnSpace(event, @toggleFlagAbuse)
-  
+
     attrRenderer:
       ability: (ability) ->
         for action, selector of @abilityRenderer
@@ -56,7 +56,7 @@ if Backbone?
 
     setWmdContent: (cls_identifier, text) =>
       DiscussionUtil.setWmdContent @$el, $.proxy(@$, @), cls_identifier, text
-      
+
 
     initialize: ->
       @model.bind('change', @renderPartialAttrs, @)

--- a/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
@@ -278,7 +278,6 @@ if Backbone?
       comment = new Comment(body: body, created_at: (new Date()).toISOString(), username: window.user.get("username"), votes: { up_count: 0 }, abuse_flaggers:[], endorsed: false, user_id: window.user.get("id"))
       comment.set('thread', @model.get('thread'))
       @renderResponseToList(comment, ".js-response-list")
-      @renderAttrs()
       @model.addComment()
       @renderAddResponseButton()
 


### PR DESCRIPTION
**Task:**

 - [Discussion: When the learner adds second response under a post, the "More" options for the first response disappears (Submitting a user response adds the response with other user's name)](https://app.asana.com/0/96288420553298/64333111492469)

**Cherry-picked from:**

  - https://github.com/edx/edx-platform/pull/11171