### PR TITLE
Sorted the Arabic countries first and translated Taiwan

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2481,14 +2481,45 @@ ANALYTICS_DASHBOARD_NAME = PLATFORM_NAME + " Insights"
 INVOICE_CORP_ADDRESS = "Please place your corporate address\nin this configuration"
 INVOICE_PAYMENT_INSTRUCTIONS = "This is where you can\nput directions on how people\nbuying registration codes"
 
+# Settings for django-countries
 # Country code overrides
-# Used by django-countries
 COUNTRIES_OVERRIDE = {
     # Taiwan is specifically not translated to avoid it being translated as "Taiwan (Province of China)"
     "TW": "Taiwan",
     "IL": None,
     "EH": None,
 }
+
+
+# Show the Arabic countries first
+COUNTRIES_FIRST = [
+    'DZ',
+    'BH',
+    'KM',
+    'DJ',
+    'EG',
+    'IQ',
+    'JO',
+    'KW',
+    'LB',
+    'LY',
+    'MR',
+    'MA',
+    'OM',
+    'PS',
+    'QA',
+    'SA',
+    'SO',
+    'SD',
+    'SY',
+    'TN',
+    'AE',
+    'YE',
+]
+
+COUNTRIES_FIRST_SORT = True  # Since the order depends on the name after translation
+
+COUNTRIES_FIRST_BREAK = '--'
 
 # which access.py permission name to check in order to determine if a course is visible in
 # the course catalog. We default this to the legacy permission 'see_exists'.

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2485,7 +2485,7 @@ INVOICE_PAYMENT_INSTRUCTIONS = "This is where you can\nput directions on how peo
 # Country code overrides
 COUNTRIES_OVERRIDE = {
     # Taiwan is specifically not translated to avoid it being translated as "Taiwan (Province of China)"
-    "TW": "Taiwan",
+    # "TW": "Taiwan",   # Edraak: We are not overriding Taiwan anymore, because we want it to be translated
     "IL": None,
     "EH": None,
 }

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -15,7 +15,7 @@ dealer==2.0.4
 defusedxml==0.4.1
 django-babel-underscore==0.4.2
 django-celery==3.1.16
-django-countries==3.3
+# django-countries==3.3 Using the Edraak fork instead in the `github.txt` file
 django-extensions==1.5.9
 django-filter==0.11.0
 django-ipware==1.1.0

--- a/requirements/edx/edraak/github.txt
+++ b/requirements/edx/edraak/github.txt
@@ -1,0 +1,2 @@
+# Use our fork to support `COUNTRIES_FIRST_SORT`
+-e git+https://github.com/Edraak/django-countries.git@a801b4b54f699da70bac2621ad5611d0adf4f14c#egg=django-countries

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -100,3 +100,6 @@ git+https://github.com/edx/xblock-lti-consumer.git@v1.0.0#egg=xblock-lti-consume
 # Third Party XBlocks
 -e git+https://github.com/mitodl/edx-sga@172a90fd2738f8142c10478356b2d9ed3e55334a#egg=edx-sga
 -e git+https://github.com/open-craft/xblock-poll@e7a6c95c300e95c51e42bfd1eba70489c05a6527#egg=xblock-poll
+
+# Edraak GitHub packages
+-r edraak/github.txt


### PR DESCRIPTION
Task:

 - [The Arab countries should show first on the registration form](https://app.asana.com/0/96288420553298/151292314351441)
 - [Registration page /Translation issue: "Tiwan" should be translated under "البلد *
" dropdown list](https://app.asana.com/0/96288420553298/131400116700981)

Related PR:

 - https://github.com/SmileyChris/django-countries/pull/141


**Testing this PR:**

 - Make sure you re-install the prerequisites using `$ NO_PREREQ_INSTALL=0 paver install_prereqs`