### PR TITLE
Hack: Disabled the responsive in the LMS, because of edX responsive problems

### DIFF
--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -15,7 +15,9 @@ from branding import api as branding_api
 <head dir="${static.dir_rtl()}">
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    ## Edraak: Disabled it because it doesn't work properly
+    ## <meta name="viewport" content="width=device-width, initial-scale=1">
 
 ## Define a couple of helper functions to make life easier when
 ## embedding theme conditionals into templates. All inheriting


### PR DESCRIPTION
Tasks:

 - [the top navigation menu is shifted down for lms pages (On Android OS, GC browser)](https://app.asana.com/0/96288420553298/96288420553298)
 - [Discussion: the discussion module is displayed improperly and the page is static (applicable on Android OS ,GC browser)](https://app.asana.com/0/96288420553298/104929382494066)
