### PR TITLE
Correct submission history date timezone 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -260,3 +260,11 @@ Jacek Bzdak <jbzdak@gmail.com>
 Jillian Vogel <pomegranited@gmail.com>
 Dan Powell <dan@abakas.com>
 Mariana Araújo <simbelm.ne@gmail.com>
+Muhammad Ayub Khan <ayub.khan@arbisoft.com>
+Kaloian Doganov <doganov@gmail.com>
+Sanford Student <sstudent@edx.org>
+Florian Haas <florian@hastexo.com>
+Leonardo Quiñonez <leonardo.quinonez@edunext.co>
+Dmitry Viskov <dmitry.viskov@webenterprise.ru>
+Brian Jacobel <bjacobel@edx.org>
+Sigberto Alarcon <salarcon@stanford.edu>

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -11,6 +11,7 @@ import unittest
 from datetime import datetime, timedelta
 from HTMLParser import HTMLParser
 from nose.plugins.attrib import attr
+from freezegun import freeze_time
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -18,6 +19,7 @@ from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponseBadRequest
 from django.test import TestCase
 from django.test.client import RequestFactory
+from django.test.client import Client
 from django.test.utils import override_settings
 from mock import MagicMock, patch, create_autospec, Mock
 from opaque_keys.edx.locations import Location, SlashSeparatedCourseKey
@@ -447,6 +449,39 @@ class ViewsTestCase(ModuleStoreTestCase):
         self.assertIn(json.dumps({'field_a': 'x', 'field_b': 'y'}, sort_keys=True, indent=2), response_content)
         self.assertIn("Score: 3.0 / 3.0", response_content)
         self.assertIn('#4', response_content)
+
+    @ddt.data(('America/New_York', -5),  # UTC - 5
+              ('Asia/Pyongyang', 9),  # UTC + 9
+              ('Europe/London', 0),  # UTC
+              ('Canada/Yukon', -8),  # UTC - 8
+              ('Europe/Moscow', 4))  # UTC + 3 + 1 for daylight savings
+    @ddt.unpack
+    @freeze_time('2012-01-01')
+    def test_submission_history_timezone(self, timezone, hour_diff):
+        with (override_settings(TIME_ZONE=timezone)):
+            course = CourseFactory.create()
+            course_key = course.id
+            client = Client()
+            admin = AdminFactory.create()
+            client.login(username=admin.username, password='test')
+            state_client = DjangoXBlockUserStateClient(admin)
+            usage_key = course_key.make_usage_key('problem', 'test-history')
+            state_client.set(
+                username=admin.username,
+                block_key=usage_key,
+                state={'field_a': 'x', 'field_b': 'y'}
+            )
+            url = reverse('submission_history', kwargs={
+                'course_id': unicode(course_key),
+                'student_username': admin.username,
+                'location': unicode(usage_key),
+            })
+            response = client.get(url)
+            response_content = HTMLParser().unescape(response.content)
+            expected_time = datetime.now() + timedelta(hours=hour_diff)
+            expected_tz = expected_time.strftime('%Z')
+            self.assertIn(expected_tz, response_content)
+            self.assertIn(str(expected_time), response_content)
 
     def _email_opt_in_checkbox(self, response, org_name_string=None):
         """Check if the email opt-in checkbox appears in the response content."""

--- a/lms/templates/courseware/submission_history.html
+++ b/lms/templates/courseware/submission_history.html
@@ -1,5 +1,6 @@
+<%page expression_filter="h"/>
 <% import json  %>
-<h3>${username | h} > ${course_id | h} > ${location | h}</h3>
+<h3>${username} > ${course_id} > ${location}</h3>
 
 % for i, (entry, score) in enumerate(zip(history_entries, scores)):
 <hr/>
@@ -7,7 +8,7 @@
 <b>#${len(history_entries) - i}</b>: ${entry.updated} UTC</br>
 Score: ${score.grade} / ${score.max_grade}
 <pre>
-${json.dumps(entry.state, indent=2, sort_keys=True) | h}
+${json.dumps(entry.state, indent=2, sort_keys=True)}
 </pre>
 </div>
 % endfor

--- a/lms/templates/courseware/submission_history.html
+++ b/lms/templates/courseware/submission_history.html
@@ -1,11 +1,13 @@
 <%page expression_filter="h"/>
-<% import json  %>
+<% import json, pytz  %>
 <h3>${username} > ${course_id} > ${location}</h3>
 
 % for i, (entry, score) in enumerate(zip(history_entries, scores)):
 <hr/>
 <div>
-<b>#${len(history_entries) - i}</b>: ${entry.updated} UTC</br>
+    <% timedate = entry.updated.astimezone(pytz.timezone(settings.TIME_ZONE))%>
+    <% timedate_str = timedate.strftime('%Y-%m-%d %H:%M:%S %Z') %>
+<b>#${len(history_entries) - i}</b>: ${timedate_str}</br>
 Score: ${score.grade} / ${score.max_grade}
 <pre>
 ${json.dumps(entry.state, indent=2, sort_keys=True)}

--- a/lms/templates/courseware/submission_history.html
+++ b/lms/templates/courseware/submission_history.html
@@ -4,7 +4,7 @@
 % for i, (entry, score) in enumerate(zip(history_entries, scores)):
 <hr/>
 <div>
-<b>#${len(history_entries) - i}</b>: ${entry.updated} (${TIME_ZONE} time)</br>
+<b>#${len(history_entries) - i}</b>: ${entry.updated} UTC</br>
 Score: ${score.grade} / ${score.max_grade}
 <pre>
 ${json.dumps(entry.state, indent=2, sort_keys=True) | h}


### PR DESCRIPTION
**Task:**
- [Learner’s Submission History: The submission time is incorrect](https://app.asana.com/0/96288420553298/138274753256335)

This pull request cherry picks the following PRs:
- https://github.com/edx/edx-platform/pull/11909 Submission History safe by default
- https://github.com/edx/edx-platform/pull/11913 This appears to actually be in UTC (not in the django TZ default)
- https://github.com/edx/edx-platform/pull/12033 Display correct timezone on timestamp for question submission

---

This is a re-open for #208 on master
