### PR TITLE
Fixed an issue with preview courses URL and ORA urls in devstack

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -39,8 +39,12 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 ################################# LMS INTEGRATION #############################
 
-LMS_BASE = "localhost:8000"
-FEATURES['PREVIEW_LMS_BASE'] = "preview." + LMS_BASE
+# Edraak: The values bellow overrides the settings of aws.py (and JSON files)
+# to hardcoded values that edX uses. Commenting out here we can use the correct
+# Edraak values.
+
+# LMS_BASE = "localhost:8000"
+# FEATURES['PREVIEW_LMS_BASE'] = "preview." + LMS_BASE
 
 ########################### PIPELINE #################################
 

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -13,7 +13,13 @@ MEDIA_ROOT = "/edx/var/edxapp/uploads"
 DEBUG = True
 USE_I18N = True
 DEFAULT_TEMPLATE_ENGINE['OPTIONS']['debug'] = True
-SITE_NAME = 'localhost:8000'
+
+# Edraak: SITE_NAME bellow overrides the settings of aws.py (and JSON files)
+# to a hardcoded value that edX uses. Commenting out here we can use the
+# correct Edraak value.
+# This makes ORA2 run on the devstack.
+# SITE_NAME = 'localhost:8000'
+
 PLATFORM_NAME = ENV_TOKENS.get('PLATFORM_NAME', 'Devstack')
 # By default don't use a worker, execute tasks as if they were local functions
 CELERY_ALWAYS_EAGER = True


### PR DESCRIPTION
This is something I need while developing.


This fixes: 

 - The ORA2 problems do not work locally.
 - The "view live" button on studio goes to the incorrect URL.

---

This is a reopen for #197 