### PR TITLE
Get back the lost PMIJO certificate logo during dogwood release 

### DIFF
--- a/lms/djangoapps/edraak_certificates/edraakcertificate.py
+++ b/lms/djangoapps/edraak_certificates/edraakcertificate.py
@@ -50,6 +50,8 @@ def get_organization_logo(organization):
         return 'crescent-petroleum.jpg'
     elif organization == 'auc':
         return 'auc.jpg'
+    elif organization == 'pmijo':
+        return 'pmijo.jpg'
     else:
         return None
 


### PR DESCRIPTION
This pull request is a part of a series of lost fixups during the dogwood merge. It is a breakdown of the closed PR #220:

> Due to the errors in the previous Dogwood pull request #161, some cypress updates were lost in the process. I'm reading them in this PR.
> 
> The affected pull requests are all the pull requests after #148 that has been merged into cypress (`master` or `edraak/core-changes`).
> 

----
 - **Ref:** #164 pmijo pic `master`
 - **Head:** 9cc770b04c66047017bc71a4cf708d3f82d5d3db
 - **Status:** Was indeed lost, cherry-picked it and got it back again
 - **Task:** I don't know, ask @devalih  