### PR TITLE
Get back the lost Solar Energy hot fixes

### DIFF
--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -125,9 +125,9 @@ def hack_remove_unwanted_modules(course, categories):
     """
 
     import re
-    SOLAR_ENERGY_COURSE = u'ET.3034TU'
+    SOLAR_ENERGY_COURSES = [u'ET.3034TU', u'SE-Pt2']
 
-    if SOLAR_ENERGY_COURSE != course.id.course:
+    if course.id.course in SOLAR_ENERGY_COURSES:
         return categories
 
     def has_english_text(text):

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -127,7 +127,7 @@ def hack_remove_unwanted_modules(course, categories):
     import re
     SOLAR_ENERGY_COURSES = [u'ET.3034TU', u'SE-Pt2']
 
-    if course.id.course in SOLAR_ENERGY_COURSES:
+    if course.id.course not in SOLAR_ENERGY_COURSES:
         return categories
 
     def has_english_text(text):


### PR DESCRIPTION
This pull request is a part of a series of lost fixups during the dogwood merge. It is a breakdown of the closed PR #220:

> Due to the errors in the previous Dogwood pull request #161, some cypress updates were lost in the process. I'm reading them in this PR.
> 
> The affected pull requests are all the pull requests after #148 that has been merged into cypress (`master` or `edraak/core-changes`).
> 

---
 - **Refs:** 
  * #188 2f71a91 Hotfix: Remove English forum entries from Solar Energy course part 2, again! `master`
  * #190 b2c3b6e Cherry-pick d0e5045 "Hotfix: Remove English forum entries from Solar Energy course part 2, one more time. `master`
 - **Status:** Cherry-picked since some changes have been lost
 - **Task:** [Introduction to Solar Energy Cells – Part 2: the discussion topics are displayed twice (in English and in Arabic) under the discussion module](https://app.asana.com/0/23241728739082/148325070732749)
 - It won't hurt to refer to the ultra old original pull request #112, but this one didn't have any lost changes.