### PR TITLE
Handled the forum's Unicode commentable_id in a better way in self-paced courses

### DIFF
--- a/lms/djangoapps/django_comment_client/permissions.py
+++ b/lms/djangoapps/django_comment_client/permissions.py
@@ -34,7 +34,7 @@ CONDITIONS = ['is_open', 'is_author', 'is_question_author', 'is_team_member_if_a
 def get_team(commentable_id):
     """ Returns the team that the commentable_id belongs to if it exists. Returns None otherwise. """
     request_cache_dict = RequestCache.get_request_cache().data
-    cache_key = "django_comment_client.team_commentable.{}".format(commentable_id)
+    cache_key = u"django_comment_client.team_commentable.{}".format(commentable_id)
     if cache_key in request_cache_dict:
         return request_cache_dict[cache_key]
 
@@ -84,9 +84,9 @@ def _check_condition(user, condition, content):
         if not content:
             return False
         try:
-            commentable_id = content['commentable_id'].encode("utf-8")
+            commentable_id = content['commentable_id']
             request_cache_dict = RequestCache.get_request_cache().data
-            cache_key = "django_comment_client.check_team_member.{}.{}".format(user.id, commentable_id)
+            cache_key = u"django_comment_client.check_team_member.{}.{}".format(user.id, commentable_id)
             if cache_key in request_cache_dict:
                 return request_cache_dict[cache_key]
             team = get_team(commentable_id)


### PR DESCRIPTION
This is a follow up on PR #194 (head e6baf41) to fix a related bug.

The reason why #194 didn't work, that it assumed that `get_team()` function is only being called by `check_team_member` which is not the case. Actually `get_team()` is used in multiple locations e.g. [forum/views.py](https://github.com/Edraak/edx-platform/blob/19765475ce98bf69cf6fe853305fa48769952f2f/lms/djangoapps/django_comment_client/forum/views.py) and [django_comment_client/utils.py](https://github.com/Edraak/edx-platform/blob/2be62b7e94ebbfe55632a8e585b9296ec75efce0/lms/djangoapps/django_comment_client/utils.py). 


**Caveat Emptor:** I couldn't reproduce the error on my vagrant machine. However, I was able to guess the issue and fix it. I used some `$ git grep -C3 commentable_id | grep -C6 format` to see where the issue is and fix it.


**Task:**

 - [Discussion : An error is occurred when the learner tries to add a new post ,response and comment](https://app.asana.com/0/96288420553298/158028810505866)