### PR TITLE
Create video upload token on course creation

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -691,6 +691,7 @@ def _create_or_rerun_course(request):
         # force the start date for reruns and allow us to override start via the client
         start = request.json.get('start', CourseFields.start.default)
         run = request.json.get('run')
+        video_upload_token = settings.VIDEO_UPLOAD_PIPELINE.get('COURSE_VIDEO_UPLOAD_TOKEN')
 
         # allow/disable unicode characters in course_id according to settings
         if not settings.FEATURES.get('ALLOW_UNICODE_COURSE_ID'):
@@ -703,6 +704,11 @@ def _create_or_rerun_course(request):
         fields = {'start': start}
         if display_name is not None:
             fields['display_name'] = display_name
+
+        if video_upload_token is not None:
+            fields['video_upload_pipeline'] = {
+                "course_video_upload_token": video_upload_token
+            }
 
         # Set a unique wiki_slug for newly created courses. To maintain active wiki_slugs for
         # existing xml courses this cannot be changed in CourseDescriptor.

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -1,6 +1,7 @@
 """
 Views related to the video upload feature
 """
+import urllib
 from boto import s3
 import csv
 from uuid import uuid4
@@ -314,6 +315,8 @@ def videos_post(course, request):
             ("course_video_upload_token", course_video_upload_token),
             ("client_video_id", file_name),
             ("course_key", unicode(course.id)),
+            # Edraak: This is needed in the edraak video processor for youtube deployments
+            ("course_title", urllib.quote_plus(course.display_name.encode("utf-8"))),
         ]:
             key.set_metadata(metadata_name, value)
         upload_url = key.generate_url(

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -712,6 +712,7 @@ VIDEO_UPLOAD_PIPELINE = {
     'BUCKET': '',
     'ROOT_PATH': '',
     'CONCURRENT_UPLOAD_LIMIT': 4,
+    'COURSE_VIDEO_UPLOAD_TOKEN': None,
 }
 
 ############################ APPS #####################################


### PR DESCRIPTION
### Description

TASK: [Implement the Video Upload Pipeline](https://app.asana.com/0/35717934599877/166547139407521)

This Change will allow us to generate a fixed pre-defined Video Upload Token upon course creation. EdX is generating different tokens for different courses, I do not think that we need this flow in our platform so I created a pre-defined token in the [configurations #9](https://github.com/Edraak/configuration/pull/9) and assigning it to the course on every new rerunning or creating courses.

### Notes
- Use [studio.jazzar.edraakbeta.org](https://studio.jazzar.edraakbeta.org) to test against
- You may want to consider: [Edraak Video Processor](https://github.com/Edraak/edraak-video-processor)
- You may want to consider: configurations PR [#9](https://github.com/Edraak/configuration/pull/9)

### Testing
- [x] Check the **Course Video Upload Token** in _Advanced Settings_ for any course in _Studio_.
- [x] **Creating a new course** in _Studio_ and see the section _Upload Videos_ under _Content_.
- [x] **Rerun new and old courses** in _Studio_ and see the section _Upload Videos_ under _Content_.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @OmarIthawi 
- [ ] FYI @lbashayreh 
- [ ] FYI @halawa 