### PR TITLE
Fixed an error with `$ paver i18n_edraak_push` when having duplicate strings

### DIFF
--- a/lms/templates/edraak_university/instructor/delete.html
+++ b/lms/templates/edraak_university/instructor/delete.html
@@ -22,7 +22,7 @@
 
 <div class="container">
     <div class="course-wrapper">
-        <div class="university-id" id="course-university-id" aria-label="${_('University ID')}">
+        <div class="university-id" id="course-university-id">
             <h1>${_('Edraak University IDs')}</h1>
 
             <hr />

--- a/lms/templates/edraak_university/instructor/list.html
+++ b/lms/templates/edraak_university/instructor/list.html
@@ -22,7 +22,7 @@
 
 <div class="container">
     <div class="course-wrapper profile-wrapper">
-        <div class="university-id" id="course-university-id" aria-label="${_('University ID')}">
+        <div class="university-id" id="course-university-id">
             <h1>${_('Edraak University IDs')}</h1>
 
             <hr />
@@ -31,7 +31,7 @@
                 <thead>
                     <tr>
                         <th>${_('Username')}</th>
-                        <th>${_('University ID')}</th>
+                        <th>${_('Student\'s University ID')}</th>
                         <th>${_('Full Name')}</th>
                         <th>${_('Email')}</th>
                         <th>${_('Section Number')}</th>

--- a/lms/templates/edraak_university/instructor/update.html
+++ b/lms/templates/edraak_university/instructor/update.html
@@ -22,7 +22,7 @@
 
 <div class="container">
     <div class="course-wrapper">
-        <div class="university-id" id="course-university-id" aria-label="${_('University ID')}">
+        <div class="university-id" id="course-university-id">
             <h1>${_('Edraak University IDs')}</h1>
             <form class="university-id-form" method="post">
                 <div class="fields">


### PR DESCRIPTION
### Description

TASK: No task.

Fixed an error with `$ paver i18n_edraak_push` when having duplicate strings in different domains e.g. Mako and Python.

### Testing
- [ ] i18n: Currently `$ paver i18n_edraak_push` is not working on master. This makes it working.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Reviewer: @devalih 
- [ ] FYI @ahmedaljazzar 
