### PR TITLE
Getting third party auth param  without failure to protect the mobile…

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1505,7 +1505,7 @@ def create_account_with_params(request, params):
 
     if should_link_with_social_auth or (third_party_auth.is_enabled() and pipeline.running(request)):
         params["password"] = pipeline.make_random_password()
-    elif params["is_third_party_auth"]:
+    elif params.get("is_third_party_auth"):
         # Hack by Edraak to detect timed-out social login attempts.
         raise ValidationError({
             "password": _("Registration process has timed out. Please refresh the page and start over.")


### PR DESCRIPTION
### Description

TASK: No task assigned.

This a minor fix to the hack added in [664e7ee](https://github.com/Edraak/edx-platform/commit/664e7ee0c1700c68b1f64dccf789029c8f928602). It was basically throws an error in the application registration module.

Already discussed with @OmarIthawi and he approved the solution, but no guarantees, so please test. 
