### PR TITLE
Keeping the requested language stored in case it is needed

### DIFF
--- a/common/djangoapps/edraak_i18n/middleware.py
+++ b/common/djangoapps/edraak_i18n/middleware.py
@@ -15,7 +15,15 @@ class ForceLangMiddleware(object):
     """
     def process_request(self, request):
         if 'HTTP_ACCEPT_LANGUAGE' in request.META:
-            del request.META['HTTP_ACCEPT_LANGUAGE']
+            # Store the requested language in another variable in
+            # case some one needed it later
+            request.META['ORIGINAL_HTTP_ACCEPT_LANGUAGE'] = \
+                request.META['HTTP_ACCEPT_LANGUAGE']
+
+            # Make the accept language as same as the site original
+            # language regardless of the original value
+            request.META['HTTP_ACCEPT_LANGUAGE'] = \
+                settings.LANGUAGE_CODE
         if 'LANG' in request.environ:
             del request.environ['LANG']
 


### PR DESCRIPTION
### Description

The Force language middleware was trying to delete the `Accept-Language` from the request so the `LocaleMiddleware` falls back to the default language of the website. However, we are required to use the value of the `Accept-Language` in some API calls, so what I did in this change is storing the value of the original request in case it needed later.

### Notes
- Using accept language is required for the mobile apps calls.
- Removing the middleware will make the default language English.

### Testing
- [ ] i18n
- [ ] RTL
- [ ] Backward compatibility
