### PR TITLE
API retrieve course data from marketing

### DIFF
--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -90,3 +90,20 @@ class CourseDetailSerializer(CourseSerializer):  # pylint: disable=abstract-meth
         # fields from CourseSerializer, which get their data
         # from the CourseOverview object in SQL.
         return CourseDetails.fetch_about_attribute(course_overview.id, 'overview')
+
+
+class MarketingCourseDetailSerializer(CourseDetailSerializer):
+    """
+    Serializer for Course detailed objects providing additional details
+    about the course fetched from Marketing site.
+    """
+
+    def get_overview(self, course_overview):
+        """
+        Get the representation for SerializerMethodField `overview`
+
+        :returns a dummy overview fetched from the  marketing,
+        so you'll never find the value returned in the database
+        """
+
+        return course_overview.overview

--- a/lms/djangoapps/course_api/urls.py
+++ b/lms/djangoapps/course_api/urls.py
@@ -4,12 +4,19 @@ Course API URLs
 from django.conf import settings
 from django.conf.urls import patterns, url, include
 
-from .views import CourseDetailView, CourseListView
+from .views import (
+    CourseDetailView, CourseListView, MarketingCourseDetailView
+)
 
+# EDRAAK: if marketing site is enabled use the marketing details
+if settings.FEATURES.get('ENABLE_MKTG_SITE'):
+    course_detail_view = MarketingCourseDetailView.as_view()
+else:
+    course_detail_view = CourseDetailView.as_view()
 
 urlpatterns = patterns(
     '',
     url(r'^v1/courses/$', CourseListView.as_view(), name="course-list"),
-    url(r'^v1/courses/{}'.format(settings.COURSE_KEY_PATTERN), CourseDetailView.as_view(), name="course-detail"),
+    url(r'^v1/courses/{}'.format(settings.COURSE_KEY_PATTERN), course_detail_view, name="course-detail"),
     url(r'', include('course_api.blocks.urls'))
 )

--- a/lms/djangoapps/course_api/views.py
+++ b/lms/djangoapps/course_api/views.py
@@ -2,14 +2,20 @@
 Course API Views
 """
 
+import requests
+from urlparse import urljoin
+
 from django.core.exceptions import ValidationError
+from django.conf import settings
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 
+from edxmako.shortcuts import marketing_link
 from openedx.core.lib.api.paginators import NamespacedPageNumberPagination
 from openedx.core.lib.api.view_utils import view_auth_classes, DeveloperErrorViewMixin
 from .api import course_detail, list_courses
 from .forms import CourseDetailGetForm, CourseListGetForm
-from .serializers import CourseSerializer, CourseDetailSerializer
+from .serializers import CourseSerializer, CourseDetailSerializer, \
+    MarketingCourseDetailSerializer
 
 
 @view_auth_classes(is_authenticated=False)
@@ -206,3 +212,147 @@ class CourseListView(DeveloperErrorViewMixin, ListAPIView):
             org=form.cleaned_data['org'],
             filter_=form.cleaned_data['filter_'],
         )
+
+
+class MarketingCourseDetailView(CourseDetailView):
+    """
+    **Use Cases**
+
+        Request marketing details for a course
+
+    **Example Requests**
+
+        GET /api/courses/v1/courses/{course_key}/
+
+    **Response Values**
+
+        Body consists of the following fields:
+
+        * effort: A textual description of the weekly hours of effort expected
+            in the course.
+        * end: Date the course ends, in ISO 8601 notation
+        * enrollment_end: Date enrollment ends, in ISO 8601 notation
+        * enrollment_start: Date enrollment begins, in ISO 8601 notation
+        * id: A unique identifier of the course; a serialized representation
+            of the opaque key identifying the course.
+        * media: An object that contains named media items.  Included here:
+            * course_image: An image to show for the course.  Represented
+              as an object with the following fields:
+                * uri: The location of the image
+        * name: Name of the course
+        * number: Catalog number of the course
+        * org: Name of the organization that owns the course
+        * overview: A possibly verbose HTML textual description of the course.
+            Note: this field is only included in the Course Detail view, not
+            the Course List view.
+        * short_description: A textual description of the course
+        * start: Date the course begins, in ISO 8601 notation
+        * start_display: Readably formatted start of the course
+        * start_type: Hint describing how `start_display` is set. One of:
+            * `"string"`: manually set by the course author
+            * `"timestamp"`: generated from the `start` timestamp
+            * `"empty"`: no start date is specified
+        * pacing: Course pacing. Possible values: instructor, self
+
+        Deprecated fields:
+
+        * blocks_url: Used to fetch the course blocks
+        * course_id: Course key (use 'id' instead)
+
+    **Parameters:**
+
+        username (optional):
+            The username of the specified user for whom the course data
+            is being accessed. The username is not only required if the API is
+            requested by an Anonymous user.
+
+    **Returns**
+
+        * 200 on success with above fields.
+        * 400 if an invalid parameter was sent or the username was not provided
+          for an authenticated request.
+        * 403 if a user who does not have permission to masquerade as
+          another user specifies a username other than their own.
+        * 404 if the course is not available or cannot be seen.
+
+        Example response:
+
+            {
+                "blocks_url": "/api/courses/v1/blocks/?course_id=edX%2Fexample%2F2012_Fall",
+                "media": {
+                    "course_image": {
+                        "uri": "/c4x/edX/example/asset/just_a_test.jpg",
+                        "name": "Course Image"
+                    }
+                },
+                "description": "An example course.",
+                "end": "2015-09-19T18:00:00Z",
+                "enrollment_end": "2015-07-15T00:00:00Z",
+                "enrollment_start": "2015-06-15T00:00:00Z",
+                "course_id": "edX/example/2012_Fall",
+                "name": "Example Course",
+                "number": "example",
+                "org": "edX",
+                "overview: "<p>A verbose description of the course.</p>"
+                "start": "2015-07-17T12:00:00Z",
+                "start_display": "July 17, 2015",
+                "start_type": "timestamp",
+                "pacing": "instructor"
+            }
+    """
+
+    serializer_class = MarketingCourseDetailSerializer
+
+    def get_object(self):
+        """
+        Return the requested course object with marketing details,
+        if the user has appropriate permissions.
+        """
+        course_object = super(MarketingCourseDetailView, self).get_object()
+
+        # NOTE: The course object is mutable
+        self.inject_marketing_details(course_object)
+        return course_object
+
+    def inject_marketing_details(self, course_object):
+        """
+        This method will edit the course object values from the
+        marketing API. The Marketing values will not be saved,
+        so the object will not be edited in the database.
+
+        It returns without editing the object if no marketing details
+        found.
+        
+        :param course_object: The object we want to alter
+        """
+        marketing_data = self.get_marketing_data()
+        if marketing_data:
+            course_object.effort = marketing_data['estimated_effort']
+            course_object.display_name = marketing_data['name']
+            course_object.course_image_url = marketing_data['course_image']
+            course_object.course_video_url = marketing_data['course_video']
+            course_object.short_description = marketing_data['short_description']
+            course_object.overview = marketing_data['overview']
+
+    def get_marketing_data(self):
+        """
+        This method gets the current marketing details for a specific
+        course.
+        :returns a course details from the marketing API or None if
+        no marketing details found.
+        """
+        course_key = self.kwargs['course_key_string']
+        language = self.request.META.get(
+            'ORIGINAL_HTTP_ACCEPT_LANGUAGE', settings.LANGUAGE_CODE)
+        headers = {'Accept-Language': language}
+
+        # Get the marketing url
+        marketing_root = marketing_link('ROOT')
+        # Marketing API path
+        marketing_api = 'api/marketing/courses/{}'.format(course_key)
+        url = urljoin(marketing_root, marketing_api)
+
+        response = requests.get(url, headers=headers)
+        if response.status_code != 200:
+            return None
+        return response.json()

--- a/lms/djangoapps/mobile_api/users/serializers.py
+++ b/lms/djangoapps/mobile_api/users/serializers.py
@@ -4,10 +4,11 @@ Serializer for user API
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
+from course_modes.helpers import COURSE_INFO_PAGE, get_mktg_for_course
+
 from courseware.access import has_access
 from student.models import CourseEnrollment, User
 from certificates.api import certificate_downloadable_status
-
 
 class CourseOverviewField(serializers.RelatedField):
     """
@@ -55,6 +56,8 @@ class CourseOverviewField(serializers.RelatedField):
                 kwargs={'course_id': course_id},
                 request=request,
             ),
+            'course_info': get_mktg_for_course(
+                COURSE_INFO_PAGE, course_id),
             'course_updates': reverse(
                 'course-updates-list',
                 kwargs={'course_id': course_id},


### PR DESCRIPTION
### Description

TASK: No associated task

In order to avoid duplicate work, I made a new view that will be activated if the marketing site is activated to fetch the course details from marketing. This is done simply by requesting the data from the marketing end-point and placing them in the course object before returning it without modifying the actual content of the object.

I also read the `Accept-Language` from the session `REQUEST_LANGUAGE` variable. (more details in #257)
### Notes
- Please don't merge before #257
- This is contain one commit, but rebased on [jazzar/language-fix](https://github.com/Edraak/edx-platform/pull/258)
- Related PRs: 
  - edx-platform #257: Keeping the requested language stored in case it is needed
  - marketing-site [#14](https://github.com/Edraak/marketing-site/pull/14): Setup marketing courses API
### Testing
- [ ] i18n
- [ ] Database and backwards-compatible
