### PR TITLE
Translation/Timed Exam: Under subsection, "Timed Exam", Course Navigation Pane

### DIFF
--- a/lms/templates/courseware/accordion.html
+++ b/lms/templates/courseware/accordion.html
@@ -44,9 +44,14 @@ else:
                 % if section['format'] or due_date or 'proctoring' in section:
                 <p class="subtitle">
                     % if 'proctoring' in section:
+                        <%
+                            exam_description = section['proctoring'].get('short_description', '')
+                            if exam_description == 'Timed Exam':
+                                exam_description = _('Timed Exam')
+                        %>
                         ## Display the proctored exam status icon and status message
                         <span class="menu-icon icon fa ${section['proctoring'].get('suggested_icon', 'fa-pencil-square-o')} ${section['proctoring'].get('status', 'eligible')}" aria-hidden="true"></span>
-                        <span class="subtitle-name">${section['proctoring'].get('short_description', '')}</span>
+                        <span class="subtitle-name">${exam_description}</span>
 
                         ## completed proctored exam statuses should not show the due date
                         ## since the exam has already been submitted by the user


### PR DESCRIPTION
### Description

TASK: [Translation/timed exam: The timed exam lable which display  in the course navigation pane should be tranlsated ](https://app.asana.com/0/198215864990333/156926104025650)

### Notes
- **Timed Exam** in CMS already translats, however translation is in djangojs po file.
- Tried adding ```#Translators: Edraak-specific``` in _course-outline.underscore_, however ```section['proctoring'].get('short_description', '')``` in _accordion.html_ always returns **Translated** string, even when platform is in English.
- Best solution was to get the subsection proctoring description from section in chapter[sections] then translate it in place.

### Testing
- [ ] i18n
- [ ] RTL

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @OmarIthawi 