### PR TITLE
(WIP) More complete is_enabled for the UniversityID tab

### DIFF
--- a/lms/djangoapps/edraak_university/tab.py
+++ b/lms/djangoapps/edraak_university/tab.py
@@ -16,4 +16,10 @@ class UniversityIDTab(EnrolledTab):
 
     @classmethod
     def is_enabled(cls, course, user=None):
-        return course.enable_university_id
+        if not user:
+            return False
+
+        if not course.enable_university_id:
+            return False
+
+        return EnrolledTab.is_enabled(course, user)


### PR DESCRIPTION
### Description

TASK: No Asana task.

The `UniversityIDTab` was enabled more than it's needed. This disables the `UniversityIDTab` when it's not needed.

I read [about the EnrolledTab](https://openedx.atlassian.net/wiki/display/AC/Adding+a+new+course+tab?focusedCommentId=141525364#comment-141525364) and realized that I forgot to include the `is_enabled` logic into `UniversityIDTab`.

## TODO

 - [ ] Add tests.

### Reviewers
- [ ] Code review: @Salomari1987 

