### PR TITLE
Picking discussion_api pagination from edX

### DIFF
--- a/common/djangoapps/enrollment/data.py
+++ b/common/djangoapps/enrollment/data.py
@@ -8,11 +8,12 @@ from django.contrib.auth.models import User
 from opaque_keys.edx.keys import CourseKey
 
 from enrollment.errors import (
-    CourseNotFoundError, CourseEnrollmentClosedError, CourseEnrollmentFullError,
+    CourseEnrollmentClosedError, CourseEnrollmentFullError,
     CourseEnrollmentExistsError, UserNotFoundError, InvalidEnrollmentAttribute
 )
 from enrollment.serializers import CourseEnrollmentSerializer, CourseSerializer
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.lib.exceptions import CourseNotFoundError
 from student.models import (
     CourseEnrollment, NonExistentCourseError, EnrollmentClosedError,
     CourseFullError, AlreadyEnrolledError, CourseEnrollmentAttribute

--- a/common/djangoapps/enrollment/errors.py
+++ b/common/djangoapps/enrollment/errors.py
@@ -13,10 +13,6 @@ class CourseEnrollmentError(Exception):
         self.data = data
 
 
-class CourseNotFoundError(CourseEnrollmentError):
-    pass
-
-
 class UserNotFoundError(CourseEnrollmentError):
     pass
 

--- a/common/djangoapps/enrollment/tests/test_data.py
+++ b/common/djangoapps/enrollment/tests/test_data.py
@@ -11,9 +11,10 @@ from django.conf import settings
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 from enrollment.errors import (
-    CourseNotFoundError, UserNotFoundError, CourseEnrollmentClosedError,
+    UserNotFoundError, CourseEnrollmentClosedError,
     CourseEnrollmentFullError, CourseEnrollmentExistsError,
 )
+from openedx.core.lib.exceptions import CourseNotFoundError
 from student.tests.factories import UserFactory, CourseModeFactory
 from student.models import CourseEnrollment, EnrollmentClosedError, CourseFullError, AlreadyEnrolledError
 from enrollment import data

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -24,11 +24,13 @@ from openedx.core.lib.api.authentication import (
     SessionAuthenticationAllowInactiveUser,
     OAuth2AuthenticationAllowInactiveUser,
 )
+from openedx.core.lib.exceptions import CourseNotFoundError
 from util.disable_rate_limit import can_disable_rate_limit
 from enrollment import api
 from enrollment.errors import (
-    CourseNotFoundError, CourseEnrollmentError,
-    CourseModeNotFoundError, CourseEnrollmentExistsError
+    CourseEnrollmentError,
+    CourseModeNotFoundError,
+    CourseEnrollmentExistsError
 )
 from student.auth import user_has_role
 from student.models import User

--- a/lms/djangoapps/course_structure_api/v0/views.py
+++ b/lms/djangoapps/course_structure_api/v0/views.py
@@ -23,6 +23,7 @@ from courseware.model_data import FieldDataCache
 from courseware.module_render import get_module_for_descriptor
 from openedx.core.lib.api.view_utils import view_course_access, view_auth_classes
 from openedx.core.djangoapps.content.course_structures.api.v0 import api, errors
+from openedx.core.lib.exceptions import CourseNotFoundError
 from student.roles import CourseInstructorRole, CourseStaffRole
 from util.module_utils import get_dynamic_descriptor_children
 
@@ -73,7 +74,7 @@ class CourseViewMixin(object):
                 self.course_key = CourseKey.from_string(course_id)
                 self.check_course_permissions(self.request.user, self.course_key)
                 return func(self, *args, **kwargs)
-            except errors.CourseNotFoundError:
+            except CourseNotFoundError:
                 raise Http404
 
         return func_wrapper

--- a/lms/djangoapps/discussion_api/api.py
+++ b/lms/djangoapps/discussion_api/api.py
@@ -16,6 +16,7 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.locator import CourseKey
 from courseware.courses import get_course_with_access
 
+from discussion_api.exceptions import ThreadNotFoundError, CommentNotFoundError, DiscussionDisabledError
 from discussion_api.forms import CommentActionsForm, ThreadActionsForm
 from discussion_api.pagination import get_paginated_data
 from discussion_api.permissions import (
@@ -41,17 +42,21 @@ from lms.lib.comment_client.comment import Comment
 from lms.lib.comment_client.thread import Thread
 from lms.lib.comment_client.utils import CommentClientRequestError
 from openedx.core.djangoapps.course_groups.cohorts import get_cohort_id
+from openedx.core.lib.exceptions import CourseNotFoundError, PageNotFoundError
 
 
-def _get_course_or_404(course_key, user):
+def _get_course(course_key, user):
     """
-    Get the course descriptor, raising Http404 if the course is not found,
-    the user cannot access forums for the course, or the discussion tab is
-    disabled for the course.
+    Get the course descriptor, raising CourseNotFoundError if the course is not found or
+    the user cannot access forums for the course, and DiscussionDisabledError if the
+    discussion tab is disabled for the course.
     """
-    course = get_course_with_access(user, 'load', course_key, check_if_enrolled=True)
+    try:
+        course = get_course_with_access(user, 'load', course_key, check_if_enrolled=True)
+    except Http404:
+        raise CourseNotFoundError("Course not found.")
     if not any([tab.type == 'discussion' and tab.is_enabled(course, user) for tab in course.tabs]):
-        raise Http404
+        raise DiscussionDisabledError("Discussion is disabled for the course.")
     return course
 
 
@@ -60,8 +65,8 @@ def _get_thread_and_context(request, thread_id, retrieve_kwargs=None):
     Retrieve the given thread and build a serializer context for it, returning
     both. This function also enforces access control for the thread (checking
     both the user's access to the course and to the thread's cohort if
-    applicable). Raises Http404 if the thread does not exist or the user cannot
-    access it.
+    applicable). Raises ThreadNotFoundError if the thread does not exist or the
+    user cannot access it.
     """
     retrieve_kwargs = retrieve_kwargs or {}
     try:
@@ -69,7 +74,7 @@ def _get_thread_and_context(request, thread_id, retrieve_kwargs=None):
             retrieve_kwargs["mark_as_read"] = False
         cc_thread = Thread(id=thread_id).retrieve(**retrieve_kwargs)
         course_key = CourseKey.from_string(cc_thread["course_id"])
-        course = _get_course_or_404(course_key, request.user)
+        course = _get_course(course_key, request.user)
         context = get_context(course, request, cc_thread)
         if (
                 not context["is_requester_privileged"] and
@@ -78,12 +83,12 @@ def _get_thread_and_context(request, thread_id, retrieve_kwargs=None):
         ):
             requester_cohort = get_cohort_id(request.user, course.id)
             if requester_cohort is not None and cc_thread["group_id"] != requester_cohort:
-                raise Http404
+                raise ThreadNotFoundError("Thread not found.")
         return cc_thread, context
     except CommentClientRequestError:
         # params are validated at a higher level, so the only possible request
         # error is if the thread doesn't exist
-        raise Http404
+        raise ThreadNotFoundError("Thread not found.")
 
 
 def _get_comment_and_context(request, comment_id):
@@ -91,15 +96,15 @@ def _get_comment_and_context(request, comment_id):
     Retrieve the given comment and build a serializer context for it, returning
     both. This function also enforces access control for the comment (checking
     both the user's access to the course and to the comment's thread's cohort if
-    applicable). Raises Http404 if the comment does not exist or the user cannot
-    access it.
+    applicable). Raises CommentNotFoundError if the comment does not exist or the
+    user cannot access it.
     """
     try:
         cc_comment = Comment(id=comment_id).retrieve()
         _, context = _get_thread_and_context(request, cc_comment["thread_id"])
         return cc_comment, context
     except CommentClientRequestError:
-        raise Http404
+        raise CommentNotFoundError("Comment not found.")
 
 
 def _is_user_author_or_privileged(cc_content, context):
@@ -146,10 +151,10 @@ def get_course(request, course_key):
 
     Raises:
 
-        Http404: if the course does not exist or is not accessible to the
-          requesting user
+        CourseNotFoundError: if the course does not exist or is not accessible
+        to the requesting user
     """
-    course = _get_course_or_404(course_key, request.user)
+    course = _get_course(course_key, request.user)
     return {
         "id": unicode(course_key),
         "blackouts": [
@@ -184,8 +189,7 @@ def get_course_topics(request, course_key):
         setting if absent)
         """
         return module.sort_key or module.discussion_target
-
-    course = _get_course_or_404(course_key, request.user)
+    course = _get_course(course_key, request.user)
     discussion_modules = get_accessible_discussion_modules(course, request.user)
     modules_by_category = defaultdict(list)
     for module in discussion_modules:
@@ -279,8 +283,8 @@ def get_thread_list(
     ValidationError: if an invalid value is passed for a field.
     ValueError: if more than one of the mutually exclusive parameters is
       provided
-    Http404: if the requesting user does not have access to the requested course
-      or a page beyond the last is requested
+    CourseNotFoundError: if the requesting user does not have access to the requested course
+    PageNotFoundError: if page requested is beyond the last
     """
     exclusive_param_count = sum(1 for param in [topic_id_list, text_search, following] if param)
     if exclusive_param_count > 1:  # pragma: no cover
@@ -297,7 +301,7 @@ def get_thread_list(
             "order_direction": ["Invalid value. '{}' must be 'asc' or 'desc'".format(order_direction)]
         })
 
-    course = _get_course_or_404(course_key, request.user)
+    course = _get_course(course_key, request.user)
     context = get_context(course, request)
 
     query_params = {
@@ -332,9 +336,9 @@ def get_thread_list(
         threads, result_page, num_pages, text_search_rewrite = Thread.search(query_params)
     # The comments service returns the last page of results if the requested
     # page is beyond the last page, but we want be consistent with DRF's general
-    # behavior and return a 404 in that case
+    # behavior and return a PageNotFoundError in that case
     if result_page != page:
-        raise Http404
+        raise PageNotFoundError("Page not found (No results on this page).")
 
     results = [ThreadSerializer(thread, context=context).data for thread in threads]
     ret = get_paginated_data(request, results, page, num_pages)
@@ -402,9 +406,9 @@ def get_comment_list(request, thread_id, endorsed, page, page_size):
 
     # The comments service returns the last page of results if the requested
     # page is beyond the last page, but we want be consistent with DRF's general
-    # behavior and return a 404 in that case
+    # behavior and return a PageNotFoundError in that case
     if not responses and page != 1:
-        raise Http404
+        raise PageNotFoundError("Page not found (No results on this page).")
     num_pages = (resp_total + page_size - 1) / page_size if resp_total else 1
 
     results = [CommentSerializer(response, context=context).data for response in responses]
@@ -535,8 +539,8 @@ def create_thread(request, thread_data):
         raise ValidationError({"course_id": ["This field is required."]})
     try:
         course_key = CourseKey.from_string(course_id)
-        course = _get_course_or_404(course_key, user)
-    except (Http404, InvalidKeyError):
+        course = _get_course(course_key, user)
+    except InvalidKeyError:
         raise ValidationError({"course_id": ["Invalid value."]})
 
     context = get_context(course, request)
@@ -581,10 +585,7 @@ def create_comment(request, comment_data):
     thread_id = comment_data.get("thread_id")
     if not thread_id:
         raise ValidationError({"thread_id": ["This field is required."]})
-    try:
-        cc_thread, context = _get_thread_and_context(request, thread_id)
-    except Http404:
-        raise ValidationError({"thread_id": ["Invalid value."]})
+    cc_thread, context = _get_thread_and_context(request, thread_id)
 
     # if a thread is closed; no new comments could be made to it
     if cc_thread['closed']:
@@ -660,8 +661,8 @@ def update_comment(request, comment_id, update_data):
 
     Raises:
 
-        Http404: if the comment does not exist or is not accessible to the
-          requesting user
+        CommentNotFoundError: if the comment does not exist or is not accessible
+        to the requesting user
 
         PermissionDenied: if the comment is accessible to but not editable by
           the requesting user
@@ -752,7 +753,7 @@ def get_response_comments(request, comment_id, page, page_size):
         num_pages = (comments_count + page_size - 1) / page_size if comments_count else 1
         return get_paginated_data(request, results, page, num_pages)
     except CommentClientRequestError:
-        raise Http404
+        raise CommentNotFoundError("Comment not found")
 
 
 def delete_thread(request, thread_id):

--- a/lms/djangoapps/discussion_api/api.py
+++ b/lms/djangoapps/discussion_api/api.py
@@ -127,7 +127,8 @@ def get_thread_list_url(request, course_key, topic_id_list=None, following=False
     path = reverse("thread-list")
     query_list = (
         [("course_id", unicode(course_key))] +
-        [("topic_id", topic_id) for topic_id in topic_id_list or []] +
+        # Edraak (fix): Supporting some of the discussion topics written in Arabic
+        [("topic_id", topic_id.encode('utf-8')) for topic_id in topic_id_list or []] +
         ([("following", following)] if following else [])
     )
     return request.build_absolute_uri(urlunparse(("", "", path, "", urlencode(query_list), "")))

--- a/lms/djangoapps/discussion_api/api.py
+++ b/lms/djangoapps/discussion_api/api.py
@@ -18,7 +18,6 @@ from courseware.courses import get_course_with_access
 
 from discussion_api.exceptions import ThreadNotFoundError, CommentNotFoundError, DiscussionDisabledError
 from discussion_api.forms import CommentActionsForm, ThreadActionsForm
-from discussion_api.pagination import get_paginated_data
 from discussion_api.permissions import (
     can_delete,
     get_editable_fields,
@@ -38,6 +37,7 @@ from django_comment_common.signals import (
     comment_deleted,
 )
 from django_comment_client.utils import get_accessible_discussion_modules, is_commentable_cohorted
+from lms.djangoapps.discussion_api.pagination import DiscussionAPIPagination
 from lms.lib.comment_client.comment import Comment
 from lms.lib.comment_client.thread import Thread
 from lms.lib.comment_client.utils import CommentClientRequestError
@@ -341,9 +341,12 @@ def get_thread_list(
         raise PageNotFoundError("Page not found (No results on this page).")
 
     results = [ThreadSerializer(thread, context=context).data for thread in threads]
-    ret = get_paginated_data(request, results, page, num_pages)
-    ret["text_search_rewrite"] = text_search_rewrite
-    return ret
+
+    paginator = DiscussionAPIPagination(request, result_page, num_pages)
+    return paginator.get_paginated_response({
+        "results": results,
+        "text_search_rewrite": text_search_rewrite,
+    })
 
 
 def get_comment_list(request, thread_id, endorsed, page, page_size):
@@ -412,7 +415,8 @@ def get_comment_list(request, thread_id, endorsed, page, page_size):
     num_pages = (resp_total + page_size - 1) / page_size if resp_total else 1
 
     results = [CommentSerializer(response, context=context).data for response in responses]
-    return get_paginated_data(request, results, page, num_pages)
+    paginator = DiscussionAPIPagination(request, page, num_pages)
+    return paginator.get_paginated_response(results)
 
 
 def _check_fields(allowed_fields, data, message):
@@ -751,7 +755,8 @@ def get_response_comments(request, comment_id, page, page_size):
 
         comments_count = len(response_comments)
         num_pages = (comments_count + page_size - 1) / page_size if comments_count else 1
-        return get_paginated_data(request, results, page, num_pages)
+        paginator = DiscussionAPIPagination(request, page, num_pages)
+        return paginator.get_paginated_response(results)
     except CommentClientRequestError:
         raise CommentNotFoundError("Comment not found")
 

--- a/lms/djangoapps/discussion_api/exceptions.py
+++ b/lms/djangoapps/discussion_api/exceptions.py
@@ -1,0 +1,17 @@
+""" Errors used by the Discussion API. """
+from django.core.exceptions import ObjectDoesNotExist
+
+
+class DiscussionDisabledError(ObjectDoesNotExist):
+    """ Discussion is disabled. """
+    pass
+
+
+class ThreadNotFoundError(ObjectDoesNotExist):
+    """ Thread was not found. """
+    pass
+
+
+class CommentNotFoundError(ObjectDoesNotExist):
+    """ Comment was not found. """
+    pass

--- a/lms/djangoapps/discussion_api/pagination.py
+++ b/lms/djangoapps/discussion_api/pagination.py
@@ -47,7 +47,6 @@ class DiscussionAPIPagination(NamespacedPageNumberPagination):
         """
         self.page = _Page(page_num, num_pages)
         self.base_url = request.build_absolute_uri()
-        self.num_pages = num_pages
 
         super(DiscussionAPIPagination, self).__init__()
 
@@ -63,7 +62,7 @@ class DiscussionAPIPagination(NamespacedPageNumberPagination):
         """
         Returns total number of pages the response is divided into
         """
-        return self.num_pages
+        return self.page.num_pages
 
     def get_next_link(self):
         """

--- a/lms/djangoapps/discussion_api/pagination.py
+++ b/lms/djangoapps/discussion_api/pagination.py
@@ -2,6 +2,7 @@
 Discussion API pagination support
 """
 from rest_framework.utils.urls import replace_query_param
+from openedx.core.lib.api.paginators import NamespacedPageNumberPagination
 
 
 class _Page(object):
@@ -9,12 +10,11 @@ class _Page(object):
     Implements just enough of the django.core.paginator.Page interface to allow
     PaginationSerializer to work.
     """
-    def __init__(self, object_list, page_num, num_pages):
+    def __init__(self, page_num, num_pages):
         """
         Create a new page containing the given objects, with the given page
         number and number of pages
         """
-        self.object_list = object_list
         self.page_num = page_num
         self.num_pages = num_pages
 
@@ -35,33 +35,52 @@ class _Page(object):
         return self.page_num - 1
 
 
-def get_paginated_data(request, results, page_num, per_page):
+class DiscussionAPIPagination(NamespacedPageNumberPagination):
     """
-    Return a dict with the following values:
-
-    next: The URL for the next page
-    previous: The URL for the previous page
-    results: The results on this page
+    Subclasses NamespacedPageNumberPagination to provide custom implementation of pagination metadata
+    by overriding it's methods
     """
-    # Note: Previous versions of this function used Django Rest Framework's
-    # paginated serializer.  With the upgrade to DRF 3.1, paginated serializers
-    # have been removed.  We *could* use DRF's paginator classes, but there are
-    # some slight differences between how DRF does pagination and how we're doing
-    # pagination here.  (For example, we respond with a next_url param even if
-    # there is only one result on the current page.)  To maintain backwards
-    # compatability, we simulate the behavior that DRF used to provide.
-    page = _Page(results, page_num, per_page)
-    next_url, previous_url = None, None
-    base_url = request.build_absolute_uri()
+    def __init__(self, request, page_num, num_pages):
+        """
+        Overrides parent constructor to take information from discussion api
+        essential for the parent method
+        """
+        self.page = _Page(page_num, num_pages)
+        self.base_url = request.build_absolute_uri()
+        self.num_pages = num_pages
 
-    if page.has_next():
-        next_url = replace_query_param(base_url, "page", page.next_page_number())
+        super(DiscussionAPIPagination, self).__init__()
 
-    if page.has_previous():
-        previous_url = replace_query_param(base_url, "page", page.previous_page_number())
+    def get_result_count(self):
+        """
+        A count can't be calculated with the information coming from the
+        Forum's api, so returning 0 for the parent method to work
+        """
+        # TODO: return actual count
+        return 0
 
-    return {
-        "next": next_url,
-        "previous": previous_url,
-        "results": results,
-    }
+    def get_num_pages(self):
+        """
+        Returns total number of pages the response is divided into
+        """
+        return self.num_pages
+
+    def get_next_link(self):
+        """
+        Returns absolute url of the next page if there's a next page available
+        otherwise returns None
+        """
+        next_url = None
+        if self.page.has_next():
+            next_url = replace_query_param(self.base_url, "page", self.page.next_page_number())
+        return next_url
+
+    def get_previous_link(self):
+        """
+        Returns absolute url of the previous page if there's a previous page available
+        otherwise returns None
+        """
+        previous_url = None
+        if self.page.has_previous():
+            previous_url = replace_query_param(self.base_url, "page", self.page.previous_page_number())
+        return previous_url

--- a/lms/djangoapps/discussion_api/tests/test_api.py
+++ b/lms/djangoapps/discussion_api/tests/test_api.py
@@ -12,7 +12,6 @@ import mock
 from pytz import UTC
 
 from django.core.exceptions import ValidationError
-from django.http import Http404
 from django.test.client import RequestFactory
 
 from rest_framework.exceptions import PermissionDenied
@@ -35,6 +34,7 @@ from discussion_api.api import (
     update_thread,
     get_thread,
 )
+from discussion_api.exceptions import DiscussionDisabledError, ThreadNotFoundError, CommentNotFoundError
 from discussion_api.tests.utils import (
     CommentsServiceMockMixin,
     make_minimal_cs_comment,
@@ -49,6 +49,7 @@ from django_comment_common.models import (
 )
 from openedx.core.djangoapps.course_groups.models import CourseUserGroupPartitionGroup
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
+from openedx.core.lib.exceptions import CourseNotFoundError, PageNotFoundError
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from util.testing import UrlResetMixin
 from xmodule.modulestore.django import modulestore
@@ -99,17 +100,17 @@ class GetCourseTest(UrlResetMixin, SharedModuleStoreTestCase):
         self.request.user = self.user
 
     def test_nonexistent_course(self):
-        with self.assertRaises(Http404):
+        with self.assertRaises(CourseNotFoundError):
             get_course(self.request, CourseLocator.from_string("non/existent/course"))
 
     def test_not_enrolled(self):
         unenrolled_user = UserFactory.create()
         self.request.user = unenrolled_user
-        with self.assertRaises(Http404):
+        with self.assertRaises(CourseNotFoundError):
             get_course(self.request, self.course.id)
 
     def test_discussions_disabled(self):
-        with self.assertRaises(Http404):
+        with self.assertRaises(DiscussionDisabledError):
             get_course(self.request, _discussion_disabled_course_for(self.user).id)
 
     def test_basic(self):
@@ -226,18 +227,18 @@ class GetCourseTopicsTest(UrlResetMixin, ModuleStoreTestCase):
         return node
 
     def test_nonexistent_course(self):
-        with self.assertRaises(Http404):
+        with self.assertRaises(CourseNotFoundError):
             get_course_topics(self.request, CourseLocator.from_string("non/existent/course"))
 
     def test_not_enrolled(self):
         unenrolled_user = UserFactory.create()
         self.request.user = unenrolled_user
-        with self.assertRaises(Http404):
+        with self.assertRaises(CourseNotFoundError):
             self.get_course_topics()
 
     def test_discussions_disabled(self):
         _remove_discussion_tab(self.course, self.user.id)
-        with self.assertRaises(Http404):
+        with self.assertRaises(DiscussionDisabledError):
             self.get_course_topics()
 
     def test_without_courseware(self):
@@ -523,16 +524,16 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
         return ret
 
     def test_nonexistent_course(self):
-        with self.assertRaises(Http404):
+        with self.assertRaises(CourseNotFoundError):
             get_thread_list(self.request, CourseLocator.from_string("non/existent/course"), 1, 1)
 
     def test_not_enrolled(self):
         self.request.user = UserFactory.create()
-        with self.assertRaises(Http404):
+        with self.assertRaises(CourseNotFoundError):
             self.get_thread_list([])
 
     def test_discussions_disabled(self):
-        with self.assertRaises(Http404):
+        with self.assertRaises(DiscussionDisabledError):
             self.get_thread_list([], course=_discussion_disabled_course_for(self.user))
 
     def test_empty(self):
@@ -752,7 +753,7 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
 
         # Test page past the last one
         self.register_get_threads_response([], page=3, num_pages=3)
-        with self.assertRaises(Http404):
+        with self.assertRaises(PageNotFoundError):
             get_thread_list(self.request, self.course.id, page=4, page_size=10)
 
     @ddt.data(None, "rewritten search string")
@@ -952,21 +953,21 @@ class GetCommentListTest(CommentsServiceMockMixin, SharedModuleStoreTestCase):
     def test_nonexistent_thread(self):
         thread_id = "nonexistent_thread"
         self.register_get_thread_error_response(thread_id, 404)
-        with self.assertRaises(Http404):
+        with self.assertRaises(ThreadNotFoundError):
             get_comment_list(self.request, thread_id, endorsed=False, page=1, page_size=1)
 
     def test_nonexistent_course(self):
-        with self.assertRaises(Http404):
+        with self.assertRaises(CourseNotFoundError):
             self.get_comment_list(self.make_minimal_cs_thread({"course_id": "non/existent/course"}))
 
     def test_not_enrolled(self):
         self.request.user = UserFactory.create()
-        with self.assertRaises(Http404):
+        with self.assertRaises(CourseNotFoundError):
             self.get_comment_list(self.make_minimal_cs_thread())
 
     def test_discussions_disabled(self):
         disabled_course = _discussion_disabled_course_for(self.user)
-        with self.assertRaises(Http404):
+        with self.assertRaises(DiscussionDisabledError):
             self.get_comment_list(
                 self.make_minimal_cs_thread(
                     overrides={"course_id": unicode(disabled_course.id)}
@@ -1023,7 +1024,7 @@ class GetCommentListTest(CommentsServiceMockMixin, SharedModuleStoreTestCase):
         try:
             self.get_comment_list(thread)
             self.assertFalse(expected_error)
-        except Http404:
+        except ThreadNotFoundError:
             self.assertTrue(expected_error)
 
     @ddt.data(True, False)
@@ -1255,7 +1256,7 @@ class GetCommentListTest(CommentsServiceMockMixin, SharedModuleStoreTestCase):
             response_field: [],
             response_total_field: 5
         })
-        with self.assertRaises(Http404):
+        with self.assertRaises(PageNotFoundError):
             self.get_comment_list(thread, endorsed=endorsed_arg, page=2, page_size=5)
 
     def test_question_endorsed_pagination(self):
@@ -1327,7 +1328,7 @@ class GetCommentListTest(CommentsServiceMockMixin, SharedModuleStoreTestCase):
         )
 
         # Page past the end
-        with self.assertRaises(Http404):
+        with self.assertRaises(PageNotFoundError):
             self.get_comment_list(thread, endorsed=True, page=2, page_size=10)
 
 
@@ -1561,22 +1562,19 @@ class CreateThreadTest(
         self.assertEqual(assertion.exception.message_dict, {"course_id": ["Invalid value."]})
 
     def test_nonexistent_course(self):
-        with self.assertRaises(ValidationError) as assertion:
+        with self.assertRaises(CourseNotFoundError):
             create_thread(self.request, {"course_id": "non/existent/course"})
-        self.assertEqual(assertion.exception.message_dict, {"course_id": ["Invalid value."]})
 
     def test_not_enrolled(self):
         self.request.user = UserFactory.create()
-        with self.assertRaises(ValidationError) as assertion:
+        with self.assertRaises(CourseNotFoundError):
             create_thread(self.request, self.minimal_data)
-        self.assertEqual(assertion.exception.message_dict, {"course_id": ["Invalid value."]})
 
     def test_discussions_disabled(self):
         disabled_course = _discussion_disabled_course_for(self.user)
         self.minimal_data["course_id"] = unicode(disabled_course.id)
-        with self.assertRaises(ValidationError) as assertion:
+        with self.assertRaises(DiscussionDisabledError):
             create_thread(self.request, self.minimal_data)
-        self.assertEqual(assertion.exception.message_dict, {"course_id": ["Invalid value."]})
 
     def test_invalid_field(self):
         data = self.minimal_data.copy()
@@ -1775,23 +1773,20 @@ class CreateCommentTest(
 
     def test_thread_id_not_found(self):
         self.register_get_thread_error_response("test_thread", 404)
-        with self.assertRaises(ValidationError) as assertion:
+        with self.assertRaises(ThreadNotFoundError):
             create_comment(self.request, self.minimal_data)
-        self.assertEqual(assertion.exception.message_dict, {"thread_id": ["Invalid value."]})
 
     def test_nonexistent_course(self):
         self.register_get_thread_response(
             make_minimal_cs_thread({"id": "test_thread", "course_id": "non/existent/course"})
         )
-        with self.assertRaises(ValidationError) as assertion:
+        with self.assertRaises(CourseNotFoundError):
             create_comment(self.request, self.minimal_data)
-        self.assertEqual(assertion.exception.message_dict, {"thread_id": ["Invalid value."]})
 
     def test_not_enrolled(self):
         self.request.user = UserFactory.create()
-        with self.assertRaises(ValidationError) as assertion:
+        with self.assertRaises(CourseNotFoundError):
             create_comment(self.request, self.minimal_data)
-        self.assertEqual(assertion.exception.message_dict, {"thread_id": ["Invalid value."]})
 
     def test_discussions_disabled(self):
         disabled_course = _discussion_disabled_course_for(self.user)
@@ -1802,9 +1797,8 @@ class CreateCommentTest(
                 "commentable_id": "test_topic",
             })
         )
-        with self.assertRaises(ValidationError) as assertion:
+        with self.assertRaises(DiscussionDisabledError):
             create_comment(self.request, self.minimal_data)
-        self.assertEqual(assertion.exception.message_dict, {"thread_id": ["Invalid value."]})
 
     @ddt.data(
         *itertools.product(
@@ -1845,12 +1839,8 @@ class CreateCommentTest(
         try:
             create_comment(self.request, data)
             self.assertFalse(expected_error)
-        except ValidationError as err:
+        except ThreadNotFoundError:
             self.assertTrue(expected_error)
-            self.assertEqual(
-                err.message_dict,
-                {"thread_id": ["Invalid value."]}
-            )
 
     def test_invalid_field(self):
         data = self.minimal_data.copy()
@@ -1974,24 +1964,24 @@ class UpdateThreadTest(
 
     def test_nonexistent_thread(self):
         self.register_get_thread_error_response("test_thread", 404)
-        with self.assertRaises(Http404):
+        with self.assertRaises(ThreadNotFoundError):
             update_thread(self.request, "test_thread", {})
 
     def test_nonexistent_course(self):
         self.register_thread({"course_id": "non/existent/course"})
-        with self.assertRaises(Http404):
+        with self.assertRaises(CourseNotFoundError):
             update_thread(self.request, "test_thread", {})
 
     def test_not_enrolled(self):
         self.register_thread()
         self.request.user = UserFactory.create()
-        with self.assertRaises(Http404):
+        with self.assertRaises(CourseNotFoundError):
             update_thread(self.request, "test_thread", {})
 
     def test_discussions_disabled(self):
         disabled_course = _discussion_disabled_course_for(self.user)
         self.register_thread(overrides={"course_id": unicode(disabled_course.id)})
-        with self.assertRaises(Http404):
+        with self.assertRaises(DiscussionDisabledError):
             update_thread(self.request, "test_thread", {})
 
     @ddt.data(
@@ -2029,7 +2019,7 @@ class UpdateThreadTest(
         try:
             update_thread(self.request, "test_thread", {})
             self.assertFalse(expected_error)
-        except Http404:
+        except ThreadNotFoundError:
             self.assertTrue(expected_error)
 
     @ddt.data(
@@ -2357,23 +2347,23 @@ class UpdateCommentTest(
 
     def test_nonexistent_comment(self):
         self.register_get_comment_error_response("test_comment", 404)
-        with self.assertRaises(Http404):
+        with self.assertRaises(CommentNotFoundError):
             update_comment(self.request, "test_comment", {})
 
     def test_nonexistent_course(self):
         self.register_comment(thread_overrides={"course_id": "non/existent/course"})
-        with self.assertRaises(Http404):
+        with self.assertRaises(CourseNotFoundError):
             update_comment(self.request, "test_comment", {})
 
     def test_unenrolled(self):
         self.register_comment()
         self.request.user = UserFactory.create()
-        with self.assertRaises(Http404):
+        with self.assertRaises(CourseNotFoundError):
             update_comment(self.request, "test_comment", {})
 
     def test_discussions_disabled(self):
         self.register_comment(course=_discussion_disabled_course_for(self.user))
-        with self.assertRaises(Http404):
+        with self.assertRaises(DiscussionDisabledError):
             update_comment(self.request, "test_comment", {})
 
     @ddt.data(
@@ -2416,7 +2406,7 @@ class UpdateCommentTest(
         try:
             update_comment(self.request, "test_comment", {})
             self.assertFalse(expected_error)
-        except Http404:
+        except ThreadNotFoundError:
             self.assertTrue(expected_error)
 
     @ddt.data(*itertools.product(
@@ -2690,24 +2680,24 @@ class DeleteThreadTest(
 
     def test_thread_id_not_found(self):
         self.register_get_thread_error_response("missing_thread", 404)
-        with self.assertRaises(Http404):
+        with self.assertRaises(ThreadNotFoundError):
             delete_thread(self.request, "missing_thread")
 
     def test_nonexistent_course(self):
         self.register_thread({"course_id": "non/existent/course"})
-        with self.assertRaises(Http404):
+        with self.assertRaises(CourseNotFoundError):
             delete_thread(self.request, self.thread_id)
 
     def test_not_enrolled(self):
         self.register_thread()
         self.request.user = UserFactory.create()
-        with self.assertRaises(Http404):
+        with self.assertRaises(CourseNotFoundError):
             delete_thread(self.request, self.thread_id)
 
     def test_discussions_disabled(self):
         disabled_course = _discussion_disabled_course_for(self.user)
         self.register_thread(overrides={"course_id": unicode(disabled_course.id)})
-        with self.assertRaises(Http404):
+        with self.assertRaises(DiscussionDisabledError):
             delete_thread(self.request, self.thread_id)
 
     @ddt.data(
@@ -2770,7 +2760,7 @@ class DeleteThreadTest(
         try:
             delete_thread(self.request, self.thread_id)
             self.assertFalse(expected_error)
-        except Http404:
+        except ThreadNotFoundError:
             self.assertTrue(expected_error)
 
 
@@ -2838,20 +2828,20 @@ class DeleteCommentTest(
 
     def test_comment_id_not_found(self):
         self.register_get_comment_error_response("missing_comment", 404)
-        with self.assertRaises(Http404):
+        with self.assertRaises(CommentNotFoundError):
             delete_comment(self.request, "missing_comment")
 
     def test_nonexistent_course(self):
         self.register_comment_and_thread(
             thread_overrides={"course_id": "non/existent/course"}
         )
-        with self.assertRaises(Http404):
+        with self.assertRaises(CourseNotFoundError):
             delete_comment(self.request, self.comment_id)
 
     def test_not_enrolled(self):
         self.register_comment_and_thread()
         self.request.user = UserFactory.create()
-        with self.assertRaises(Http404):
+        with self.assertRaises(CourseNotFoundError):
             delete_comment(self.request, self.comment_id)
 
     def test_discussions_disabled(self):
@@ -2860,7 +2850,7 @@ class DeleteCommentTest(
             thread_overrides={"course_id": unicode(disabled_course.id)},
             overrides={"course_id": unicode(disabled_course.id)}
         )
-        with self.assertRaises(Http404):
+        with self.assertRaises(DiscussionDisabledError):
             delete_comment(self.request, self.comment_id)
 
     @ddt.data(
@@ -2928,7 +2918,7 @@ class DeleteCommentTest(
         try:
             delete_comment(self.request, self.comment_id)
             self.assertFalse(expected_error)
-        except Http404:
+        except ThreadNotFoundError:
             self.assertTrue(expected_error)
 
 
@@ -3017,7 +3007,7 @@ class RetrieveThreadTest(
 
     def test_thread_id_not_found(self):
         self.register_get_thread_error_response("missing_thread", 404)
-        with self.assertRaises(Http404):
+        with self.assertRaises(ThreadNotFoundError):
             get_thread(self.request, "missing_thread")
 
     def test_nonauthor_enrolled_in_course(self):
@@ -3062,7 +3052,7 @@ class RetrieveThreadTest(
     def test_not_enrolled_in_course(self):
         self.register_thread()
         self.request.user = UserFactory.create()
-        with self.assertRaises(Http404):
+        with self.assertRaises(CourseNotFoundError):
             get_thread(self.request, self.thread_id)
 
     @ddt.data(
@@ -3108,5 +3098,5 @@ class RetrieveThreadTest(
         try:
             get_thread(self.request, self.thread_id)
             self.assertFalse(expected_error)
-        except Http404:
+        except ThreadNotFoundError:
             self.assertTrue(expected_error)

--- a/lms/djangoapps/discussion_api/tests/test_api.py
+++ b/lms/djangoapps/discussion_api/tests/test_api.py
@@ -695,7 +695,7 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
         ]
 
         expected_result = make_paginated_api_response(
-            expected_threads, 0, 1, None, None
+            results=expected_threads, count=0, num_pages=1, next_link=None, previous_link=None
         )
         expected_result.update({"text_search_rewrite": None})
         self.assertEqual(
@@ -728,7 +728,9 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
 
     def test_pagination(self):
         # N.B. Empty thread list is not realistic but convenient for this test
-        expected_result = make_paginated_api_response([], 0, 3, "http://testserver/test_path?page=2", None)
+        expected_result = make_paginated_api_response(
+            results=[], count=0, num_pages=3, next_link="http://testserver/test_path?page=2", previous_link=None
+        )
         expected_result.update({"text_search_rewrite": None})
         self.assertEqual(
             self.get_thread_list([], page=1, num_pages=3).data,
@@ -736,7 +738,11 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
         )
 
         expected_result = make_paginated_api_response(
-            [], 0, 3, "http://testserver/test_path?page=3", "http://testserver/test_path?page=1"
+            results=[],
+            count=0,
+            num_pages=3,
+            next_link="http://testserver/test_path?page=3",
+            previous_link="http://testserver/test_path?page=1"
         )
         expected_result.update({"text_search_rewrite": None})
         self.assertEqual(
@@ -745,7 +751,7 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
         )
 
         expected_result = make_paginated_api_response(
-            [], 0, 3, None, "http://testserver/test_path?page=2"
+            results=[], count=0, num_pages=3, next_link=None, previous_link="http://testserver/test_path?page=2"
         )
         expected_result.update({"text_search_rewrite": None})
         self.assertEqual(
@@ -761,7 +767,7 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
     @ddt.data(None, "rewritten search string")
     def test_text_search(self, text_search_rewrite):
         expected_result = make_paginated_api_response(
-            [], 0, 0, None, None
+            results=[], count=0, num_pages=0, next_link=None, previous_link=None
         )
         expected_result.update({"text_search_rewrite": text_search_rewrite})
         self.register_get_threads_search_response([], text_search_rewrite, num_pages=0)
@@ -796,7 +802,9 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
             following=True,
         ).data
 
-        expected_result = make_paginated_api_response([], 0, 0, None, None)
+        expected_result = make_paginated_api_response(
+            results=[], count=0, num_pages=0, next_link=None, previous_link=None
+        )
         expected_result.update({"text_search_rewrite": None})
         self.assertEqual(
             result,
@@ -827,7 +835,7 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
         ).data
 
         expected_result = make_paginated_api_response(
-            [], 0, 0, None, None
+            results=[], count=0, num_pages=0, next_link=None, previous_link=None
         )
         expected_result.update({"text_search_rewrite": None})
         self.assertEqual(
@@ -872,7 +880,9 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
             order_by=http_query,
         ).data
 
-        expected_result = make_paginated_api_response([], 0, 0, None, None)
+        expected_result = make_paginated_api_response(
+            results=[], count=0, num_pages=0, next_link=None, previous_link=None
+        )
         expected_result.update({"text_search_rewrite": None})
         self.assertEqual(result, expected_result)
         self.assertEqual(
@@ -900,7 +910,9 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
             order_direction=http_query,
         ).data
 
-        expected_result = make_paginated_api_response([], 0, 0, None, None)
+        expected_result = make_paginated_api_response(
+            results=[], count=0, num_pages=0, next_link=None, previous_link=None
+        )
         expected_result.update({"text_search_rewrite": None})
         self.assertEqual(result, expected_result)
         self.assertEqual(
@@ -1065,7 +1077,7 @@ class GetCommentListTest(CommentsServiceMockMixin, SharedModuleStoreTestCase):
         )
         self.assertEqual(
             self.get_comment_list(discussion_thread).data,
-            make_paginated_api_response([], 0, 1, None, None)
+            make_paginated_api_response(results=[], count=0, num_pages=1, next_link=None, previous_link=None)
         )
 
         question_thread = self.make_minimal_cs_thread({
@@ -1076,11 +1088,11 @@ class GetCommentListTest(CommentsServiceMockMixin, SharedModuleStoreTestCase):
         })
         self.assertEqual(
             self.get_comment_list(question_thread, endorsed=False).data,
-            make_paginated_api_response([], 0, 1, None, None)
+            make_paginated_api_response(results=[], count=0, num_pages=1, next_link=None, previous_link=None)
         )
         self.assertEqual(
             self.get_comment_list(question_thread, endorsed=True).data,
-            make_paginated_api_response([], 0, 1, None, None)
+            make_paginated_api_response(results=[], count=0, num_pages=1, next_link=None, previous_link=None)
         )
 
     def test_basic_query_params(self):

--- a/lms/djangoapps/discussion_api/tests/test_api.py
+++ b/lms/djangoapps/discussion_api/tests/test_api.py
@@ -39,6 +39,7 @@ from discussion_api.tests.utils import (
     CommentsServiceMockMixin,
     make_minimal_cs_comment,
     make_minimal_cs_thread,
+    make_paginated_api_response
 )
 from django_comment_common.models import (
     FORUM_ROLE_ADMINISTRATOR,
@@ -538,11 +539,15 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
 
     def test_empty(self):
         self.assertEqual(
-            self.get_thread_list([]),
+            self.get_thread_list([], num_pages=0).data,
             {
+                "pagination": {
+                    "next": None,
+                    "previous": None,
+                    "num_pages": 0,
+                    "count": 0
+                },
                 "results": [],
-                "next": None,
-                "previous": None,
                 "text_search_rewrite": None,
             }
         )
@@ -688,14 +693,14 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
                 "read": False,
             },
         ]
+
+        expected_result = make_paginated_api_response(
+            expected_threads, 0, 1, None, None
+        )
+        expected_result.update({"text_search_rewrite": None})
         self.assertEqual(
-            self.get_thread_list(source_threads),
-            {
-                "results": expected_threads,
-                "next": None,
-                "previous": None,
-                "text_search_rewrite": None,
-            }
+            self.get_thread_list(source_threads).data,
+            expected_result
         )
 
     @ddt.data(
@@ -723,32 +728,29 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
 
     def test_pagination(self):
         # N.B. Empty thread list is not realistic but convenient for this test
+        expected_result = make_paginated_api_response([], 0, 3, "http://testserver/test_path?page=2", None)
+        expected_result.update({"text_search_rewrite": None})
         self.assertEqual(
-            self.get_thread_list([], page=1, num_pages=3),
-            {
-                "results": [],
-                "next": "http://testserver/test_path?page=2",
-                "previous": None,
-                "text_search_rewrite": None,
-            }
+            self.get_thread_list([], page=1, num_pages=3).data,
+            expected_result
         )
-        self.assertEqual(
-            self.get_thread_list([], page=2, num_pages=3),
-            {
-                "results": [],
-                "next": "http://testserver/test_path?page=3",
-                "previous": "http://testserver/test_path?page=1",
-                "text_search_rewrite": None,
-            }
+
+        expected_result = make_paginated_api_response(
+            [], 0, 3, "http://testserver/test_path?page=3", "http://testserver/test_path?page=1"
         )
+        expected_result.update({"text_search_rewrite": None})
         self.assertEqual(
-            self.get_thread_list([], page=3, num_pages=3),
-            {
-                "results": [],
-                "next": None,
-                "previous": "http://testserver/test_path?page=2",
-                "text_search_rewrite": None,
-            }
+            self.get_thread_list([], page=2, num_pages=3).data,
+            expected_result
+        )
+
+        expected_result = make_paginated_api_response(
+            [], 0, 3, None, "http://testserver/test_path?page=2"
+        )
+        expected_result.update({"text_search_rewrite": None})
+        self.assertEqual(
+            self.get_thread_list([], page=3, num_pages=3).data,
+            expected_result
         )
 
         # Test page past the last one
@@ -758,7 +760,11 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
 
     @ddt.data(None, "rewritten search string")
     def test_text_search(self, text_search_rewrite):
-        self.register_get_threads_search_response([], text_search_rewrite)
+        expected_result = make_paginated_api_response(
+            [], 0, 0, None, None
+        )
+        expected_result.update({"text_search_rewrite": text_search_rewrite})
+        self.register_get_threads_search_response([], text_search_rewrite, num_pages=0)
         self.assertEqual(
             get_thread_list(
                 self.request,
@@ -766,13 +772,8 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
                 page=1,
                 page_size=10,
                 text_search="test search string"
-            ),
-            {
-                "results": [],
-                "next": None,
-                "previous": None,
-                "text_search_rewrite": text_search_rewrite,
-            }
+            ).data,
+            expected_result
         )
         self.assert_last_query_params({
             "user_id": [unicode(self.user.id)],
@@ -786,17 +787,20 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
         })
 
     def test_following(self):
-        self.register_subscribed_threads_response(self.user, [], page=1, num_pages=1)
+        self.register_subscribed_threads_response(self.user, [], page=1, num_pages=0)
         result = get_thread_list(
             self.request,
             self.course.id,
             page=1,
             page_size=11,
             following=True,
-        )
+        ).data
+
+        expected_result = make_paginated_api_response([], 0, 0, None, None)
+        expected_result.update({"text_search_rewrite": None})
         self.assertEqual(
             result,
-            {"results": [], "next": None, "previous": None, "text_search_rewrite": None}
+            expected_result
         )
         self.assertEqual(
             urlparse(httpretty.last_request().path).path,
@@ -813,17 +817,22 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
 
     @ddt.data("unanswered", "unread")
     def test_view_query(self, query):
-        self.register_get_threads_response([], page=1, num_pages=1)
+        self.register_get_threads_response([], page=1, num_pages=0)
         result = get_thread_list(
             self.request,
             self.course.id,
             page=1,
             page_size=11,
             view=query,
+        ).data
+
+        expected_result = make_paginated_api_response(
+            [], 0, 0, None, None
         )
+        expected_result.update({"text_search_rewrite": None})
         self.assertEqual(
             result,
-            {"results": [], "next": None, "previous": None, "text_search_rewrite": None}
+            expected_result
         )
         self.assertEqual(
             urlparse(httpretty.last_request().path).path,
@@ -854,18 +863,18 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
             http_query (str): Query string sent in the http request
             cc_query (str): Query string used for the comments client service
         """
-        self.register_get_threads_response([], page=1, num_pages=1)
+        self.register_get_threads_response([], page=1, num_pages=0)
         result = get_thread_list(
             self.request,
             self.course.id,
             page=1,
             page_size=11,
             order_by=http_query,
-        )
-        self.assertEqual(
-            result,
-            {"results": [], "next": None, "previous": None, "text_search_rewrite": None}
-        )
+        ).data
+
+        expected_result = make_paginated_api_response([], 0, 0, None, None)
+        expected_result.update({"text_search_rewrite": None})
+        self.assertEqual(result, expected_result)
         self.assertEqual(
             urlparse(httpretty.last_request().path).path,
             "/api/v1/threads"
@@ -882,18 +891,18 @@ class GetThreadListTest(CommentsServiceMockMixin, UrlResetMixin, SharedModuleSto
 
     @ddt.data("asc", "desc")
     def test_order_direction_query(self, http_query):
-        self.register_get_threads_response([], page=1, num_pages=1)
+        self.register_get_threads_response([], page=1, num_pages=0)
         result = get_thread_list(
             self.request,
             self.course.id,
             page=1,
             page_size=11,
             order_direction=http_query,
-        )
-        self.assertEqual(
-            result,
-            {"results": [], "next": None, "previous": None, "text_search_rewrite": None}
-        )
+        ).data
+
+        expected_result = make_paginated_api_response([], 0, 0, None, None)
+        expected_result.update({"text_search_rewrite": None})
+        self.assertEqual(result, expected_result)
         self.assertEqual(
             urlparse(httpretty.last_request().path).path,
             "/api/v1/threads"
@@ -1055,8 +1064,8 @@ class GetCommentListTest(CommentsServiceMockMixin, SharedModuleStoreTestCase):
             {"thread_type": "discussion", "children": [], "resp_total": 0}
         )
         self.assertEqual(
-            self.get_comment_list(discussion_thread),
-            {"results": [], "next": None, "previous": None}
+            self.get_comment_list(discussion_thread).data,
+            make_paginated_api_response([], 0, 1, None, None)
         )
 
         question_thread = self.make_minimal_cs_thread({
@@ -1066,12 +1075,12 @@ class GetCommentListTest(CommentsServiceMockMixin, SharedModuleStoreTestCase):
             "non_endorsed_resp_total": 0
         })
         self.assertEqual(
-            self.get_comment_list(question_thread, endorsed=False),
-            {"results": [], "next": None, "previous": None}
+            self.get_comment_list(question_thread, endorsed=False).data,
+            make_paginated_api_response([], 0, 1, None, None)
         )
         self.assertEqual(
-            self.get_comment_list(question_thread, endorsed=True),
-            {"results": [], "next": None, "previous": None}
+            self.get_comment_list(question_thread, endorsed=True).data,
+            make_paginated_api_response([], 0, 1, None, None)
         )
 
     def test_basic_query_params(self):
@@ -1173,7 +1182,7 @@ class GetCommentListTest(CommentsServiceMockMixin, SharedModuleStoreTestCase):
         ]
         actual_comments = self.get_comment_list(
             self.make_minimal_cs_thread({"children": source_comments})
-        )["results"]
+        ).data["results"]
         self.assertEqual(actual_comments, expected_comments)
 
     def test_question_content(self):
@@ -1184,10 +1193,10 @@ class GetCommentListTest(CommentsServiceMockMixin, SharedModuleStoreTestCase):
             "non_endorsed_resp_total": 1,
         })
 
-        endorsed_actual = self.get_comment_list(thread, endorsed=True)
+        endorsed_actual = self.get_comment_list(thread, endorsed=True).data
         self.assertEqual(endorsed_actual["results"][0]["id"], "endorsed_comment")
 
-        non_endorsed_actual = self.get_comment_list(thread, endorsed=False)
+        non_endorsed_actual = self.get_comment_list(thread, endorsed=False).data
         self.assertEqual(non_endorsed_actual["results"][0]["id"], "non_endorsed_comment")
 
     def test_endorsed_by_anonymity(self):
@@ -1203,7 +1212,7 @@ class GetCommentListTest(CommentsServiceMockMixin, SharedModuleStoreTestCase):
                 })
             ]
         })
-        actual_comments = self.get_comment_list(thread)["results"]
+        actual_comments = self.get_comment_list(thread).data["results"]
         self.assertIsNone(actual_comments[0]["endorsed_by"])
 
     @ddt.data(
@@ -1231,24 +1240,24 @@ class GetCommentListTest(CommentsServiceMockMixin, SharedModuleStoreTestCase):
         })
 
         # Only page
-        actual = self.get_comment_list(thread, endorsed=endorsed_arg, page=1, page_size=5)
-        self.assertIsNone(actual["next"])
-        self.assertIsNone(actual["previous"])
+        actual = self.get_comment_list(thread, endorsed=endorsed_arg, page=1, page_size=5).data
+        self.assertIsNone(actual["pagination"]["next"])
+        self.assertIsNone(actual["pagination"]["previous"])
 
         # First page of many
-        actual = self.get_comment_list(thread, endorsed=endorsed_arg, page=1, page_size=2)
-        self.assertEqual(actual["next"], "http://testserver/test_path?page=2")
-        self.assertIsNone(actual["previous"])
+        actual = self.get_comment_list(thread, endorsed=endorsed_arg, page=1, page_size=2).data
+        self.assertEqual(actual["pagination"]["next"], "http://testserver/test_path?page=2")
+        self.assertIsNone(actual["pagination"]["previous"])
 
         # Middle page of many
-        actual = self.get_comment_list(thread, endorsed=endorsed_arg, page=2, page_size=2)
-        self.assertEqual(actual["next"], "http://testserver/test_path?page=3")
-        self.assertEqual(actual["previous"], "http://testserver/test_path?page=1")
+        actual = self.get_comment_list(thread, endorsed=endorsed_arg, page=2, page_size=2).data
+        self.assertEqual(actual["pagination"]["next"], "http://testserver/test_path?page=3")
+        self.assertEqual(actual["pagination"]["previous"], "http://testserver/test_path?page=1")
 
         # Last page of many
-        actual = self.get_comment_list(thread, endorsed=endorsed_arg, page=3, page_size=2)
-        self.assertIsNone(actual["next"])
-        self.assertEqual(actual["previous"], "http://testserver/test_path?page=2")
+        actual = self.get_comment_list(thread, endorsed=endorsed_arg, page=3, page_size=2).data
+        self.assertIsNone(actual["pagination"]["next"])
+        self.assertEqual(actual["pagination"]["previous"], "http://testserver/test_path?page=2")
 
         # Page past the end
         thread = self.make_minimal_cs_thread({
@@ -1272,18 +1281,18 @@ class GetCommentListTest(CommentsServiceMockMixin, SharedModuleStoreTestCase):
             Check that requesting the given page/page_size returns the expected
             output
             """
-            actual = self.get_comment_list(thread, endorsed=True, page=page, page_size=page_size)
+            actual = self.get_comment_list(thread, endorsed=True, page=page, page_size=page_size).data
             result_ids = [result["id"] for result in actual["results"]]
             self.assertEqual(
                 result_ids,
                 ["comment_{}".format(i) for i in range(expected_start, expected_stop)]
             )
             self.assertEqual(
-                actual["next"],
+                actual["pagination"]["next"],
                 "http://testserver/test_path?page={}".format(expected_next) if expected_next else None
             )
             self.assertEqual(
-                actual["previous"],
+                actual["pagination"]["previous"],
                 "http://testserver/test_path?page={}".format(expected_prev) if expected_prev else None
             )
 

--- a/lms/djangoapps/discussion_api/tests/test_forms.py
+++ b/lms/djangoapps/discussion_api/tests/test_forms.py
@@ -100,13 +100,19 @@ class ThreadListGetFormTest(FormTestMixin, PaginationTestMixin, TestCase):
         self.form_data.setlist("topic_id", ["", "not empty"])
         self.assert_error("topic_id", "This field cannot be empty.")
 
-    def test_following_true(self):
-        self.form_data["following"] = "True"
+    @ddt.data("True", "true", 1, True)
+    def test_following_true(self, value):
+        self.form_data["following"] = value
         self.assert_field_value("following", True)
 
-    def test_following_false(self):
-        self.form_data["following"] = "False"
+    @ddt.data("False", "false", 0, False)
+    def test_following_false(self, value):
+        self.form_data["following"] = value
         self.assert_error("following", "The value of the 'following' parameter must be true.")
+
+    def test_invalid_following(self):
+        self.form_data["following"] = "invalid-boolean"
+        self.assert_error("following", "Invalid Boolean Value.")
 
     @ddt.data(*itertools.combinations(["topic_id", "text_search", "following"], 2))
     def test_mutually_exclusive(self, params):
@@ -134,7 +140,22 @@ class ThreadListGetFormTest(FormTestMixin, PaginationTestMixin, TestCase):
             "Select a valid choice. not_a_valid_choice is not one of the available choices."
         )
 
+    @ddt.data(
+        ("view", "unread"),
+        ("view", "unanswered"),
+        ("order_by", "last_activity_at"),
+        ("order_by", "comment_count"),
+        ("order_by", "vote_count"),
+        ("order_direction", "asc"),
+        ("order_direction", "desc"),
+    )
+    @ddt.unpack
+    def test_valid_choice_fields(self, field, value):
+        self.form_data[field] = value
+        self.assert_field_value(field, value)
 
+
+@ddt.ddt
 class CommentListGetFormTest(FormTestMixin, PaginationTestMixin, TestCase):
     """Tests for CommentListGetForm"""
     FORM_CLASS = CommentListGetForm
@@ -167,3 +188,17 @@ class CommentListGetFormTest(FormTestMixin, PaginationTestMixin, TestCase):
     def test_missing_endorsed(self):
         self.form_data.pop("endorsed")
         self.assert_field_value("endorsed", None)
+
+    @ddt.data("True", "true", True, 1)
+    def test_endorsed_true(self, value):
+        self.form_data["endorsed"] = value
+        self.assert_field_value("endorsed", True)
+
+    @ddt.data("False", "false", False, 0)
+    def test_endorsed_false(self, value):
+        self.form_data["endorsed"] = value
+        self.assert_field_value("endorsed", False)
+
+    def test_invalid_endorsed(self):
+        self.form_data["endorsed"] = "invalid-boolean"
+        self.assert_error("endorsed", "Invalid Boolean Value.")

--- a/lms/djangoapps/discussion_api/tests/test_pagination.py
+++ b/lms/djangoapps/discussion_api/tests/test_pagination.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 from django.test import RequestFactory
 
-from discussion_api.pagination import get_paginated_data
+from discussion_api.pagination import DiscussionAPIPagination
 
 
 class PaginationSerializerTest(TestCase):
@@ -16,55 +16,51 @@ class PaginationSerializerTest(TestCase):
         parameters returns the expected result
         """
         request = RequestFactory().get("/test")
-        actual = get_paginated_data(request, objects, page_num, num_pages)
-        self.assertEqual(actual, expected)
+        paginator = DiscussionAPIPagination(request, page_num, num_pages)
+        actual = paginator.get_paginated_response(objects)
+        self.assertEqual(actual.data, expected)
+
+    def get_expected_response(self, results, count, num_pages, next, previous):
+        """
+        Generates the response dictionary with passed data
+        """
+        return {
+            "pagination": {
+                "next": next,
+                "previous": previous,
+                "count": count,
+                "num_pages": num_pages,
+            },
+            "results": results
+        }
 
     def test_empty(self):
         self.do_case(
-            [], 1, 0,
-            {
-                "next": None,
-                "previous": None,
-                "results": [],
-            }
+            [], 1, 0, self.get_expected_response([], 0, 0, None, None)
         )
 
     def test_only_page(self):
         self.do_case(
-            ["foo"], 1, 1,
-            {
-                "next": None,
-                "previous": None,
-                "results": ["foo"],
-            }
+            ["foo"], 1, 1, self.get_expected_response(["foo"], 0, 1, None, None)
         )
 
     def test_first_of_many(self):
         self.do_case(
-            ["foo"], 1, 3,
-            {
-                "next": "http://testserver/test?page=2",
-                "previous": None,
-                "results": ["foo"],
-            }
+            ["foo"], 1, 3, self.get_expected_response(
+                ["foo"], 0, 3, "http://testserver/test?page=2", None
+            )
         )
 
     def test_last_of_many(self):
         self.do_case(
-            ["foo"], 3, 3,
-            {
-                "next": None,
-                "previous": "http://testserver/test?page=2",
-                "results": ["foo"],
-            }
+            ["foo"], 3, 3, self.get_expected_response(
+                ["foo"], 0, 3, None, "http://testserver/test?page=2"
+            )
         )
 
     def test_middle_of_many(self):
         self.do_case(
-            ["foo"], 2, 3,
-            {
-                "next": "http://testserver/test?page=3",
-                "previous": "http://testserver/test?page=1",
-                "results": ["foo"],
-            }
+            ["foo"], 2, 3, self.get_expected_response(
+                ["foo"], 0, 3, "http://testserver/test?page=3", "http://testserver/test?page=1"
+            )
         )

--- a/lms/djangoapps/discussion_api/tests/test_pagination.py
+++ b/lms/djangoapps/discussion_api/tests/test_pagination.py
@@ -23,31 +23,39 @@ class PaginationSerializerTest(TestCase):
 
     def test_empty(self):
         self.do_case(
-            [], 1, 0, make_paginated_api_response([], 0, 0, None, None)
+            [], 1, 0, make_paginated_api_response(
+                results=[], count=0, num_pages=0, next_link=None, previous_link=None
+            )
         )
 
     def test_only_page(self):
         self.do_case(
-            ["foo"], 1, 1, make_paginated_api_response(["foo"], 0, 1, None, None)
+            ["foo"], 1, 1, make_paginated_api_response(
+                results=["foo"], count=0, num_pages=1, next_link=None, previous_link=None
+            )
         )
 
     def test_first_of_many(self):
         self.do_case(
             ["foo"], 1, 3, make_paginated_api_response(
-                ["foo"], 0, 3, "http://testserver/test?page=2", None
+                results=["foo"], count=0, num_pages=3, next_link="http://testserver/test?page=2", previous_link=None
             )
         )
 
     def test_last_of_many(self):
         self.do_case(
             ["foo"], 3, 3, make_paginated_api_response(
-                ["foo"], 0, 3, None, "http://testserver/test?page=2"
+                results=["foo"], count=0, num_pages=3, next_link=None, previous_link="http://testserver/test?page=2"
             )
         )
 
     def test_middle_of_many(self):
         self.do_case(
             ["foo"], 2, 3, make_paginated_api_response(
-                ["foo"], 0, 3, "http://testserver/test?page=3", "http://testserver/test?page=1"
+                results=["foo"],
+                count=0,
+                num_pages=3,
+                next_link="http://testserver/test?page=3",
+                previous_link="http://testserver/test?page=1"
             )
         )

--- a/lms/djangoapps/discussion_api/tests/test_pagination.py
+++ b/lms/djangoapps/discussion_api/tests/test_pagination.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 from django.test import RequestFactory
 
 from discussion_api.pagination import DiscussionAPIPagination
+from discussion_api.tests.utils import make_paginated_api_response
 
 
 class PaginationSerializerTest(TestCase):
@@ -20,47 +21,33 @@ class PaginationSerializerTest(TestCase):
         actual = paginator.get_paginated_response(objects)
         self.assertEqual(actual.data, expected)
 
-    def get_expected_response(self, results, count, num_pages, next, previous):
-        """
-        Generates the response dictionary with passed data
-        """
-        return {
-            "pagination": {
-                "next": next,
-                "previous": previous,
-                "count": count,
-                "num_pages": num_pages,
-            },
-            "results": results
-        }
-
     def test_empty(self):
         self.do_case(
-            [], 1, 0, self.get_expected_response([], 0, 0, None, None)
+            [], 1, 0, make_paginated_api_response([], 0, 0, None, None)
         )
 
     def test_only_page(self):
         self.do_case(
-            ["foo"], 1, 1, self.get_expected_response(["foo"], 0, 1, None, None)
+            ["foo"], 1, 1, make_paginated_api_response(["foo"], 0, 1, None, None)
         )
 
     def test_first_of_many(self):
         self.do_case(
-            ["foo"], 1, 3, self.get_expected_response(
+            ["foo"], 1, 3, make_paginated_api_response(
                 ["foo"], 0, 3, "http://testserver/test?page=2", None
             )
         )
 
     def test_last_of_many(self):
         self.do_case(
-            ["foo"], 3, 3, self.get_expected_response(
+            ["foo"], 3, 3, make_paginated_api_response(
                 ["foo"], 0, 3, None, "http://testserver/test?page=2"
             )
         )
 
     def test_middle_of_many(self):
         self.do_case(
-            ["foo"], 2, 3, self.get_expected_response(
+            ["foo"], 2, 3, make_paginated_api_response(
                 ["foo"], 0, 3, "http://testserver/test?page=3", "http://testserver/test?page=1"
             )
         )

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -360,7 +360,7 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.assert_response_correct(
             response,
             404,
-            {"developer_message": "Not found."}
+            {"developer_message": "Page not found (No results on this page)."}
         )
         self.assert_last_query_params({
             "user_id": [unicode(self.user.id)],
@@ -884,7 +884,7 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.assert_response_correct(
             response,
             404,
-            {"developer_message": "Not found."}
+            {"developer_message": "Thread not found."}
         )
 
     def test_basic(self):
@@ -976,7 +976,7 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.assert_response_correct(
             response,
             404,
-            {"developer_message": "Not found."}
+            {"developer_message": "Page not found (No results on this page)."}
         )
         self.assert_query_params_equal(
             httpretty.httpretty.latest_requests[-2],

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -309,11 +309,11 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.register_get_threads_response(source_threads, page=1, num_pages=2)
         response = self.client.get(self.url, {"course_id": unicode(self.course.id), "following": ""})
         expected_respoonse = make_paginated_api_response(
-            expected_threads,
-            0,
-            2,
-            "http://testserver/api/discussion/v1/threads/?course_id=x%2Fy%2Fz&page=2",
-            None
+            results=expected_threads,
+            count=0,
+            num_pages=2,
+            next_link="http://testserver/api/discussion/v1/threads/?course_id=x%2Fy%2Fz&page=2",
+            previous_link=None
         )
         expected_respoonse.update({"text_search_rewrite": None})
         self.assert_response_correct(
@@ -384,7 +384,9 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             {"course_id": unicode(self.course.id), "text_search": "test search string"}
         )
 
-        expected_response = make_paginated_api_response([], 0, 0, None, None)
+        expected_response = make_paginated_api_response(
+            results=[], count=0, num_pages=0, next_link=None, previous_link=None
+        )
         expected_response.update({"text_search_rewrite": None})
         self.assert_response_correct(
             response,
@@ -414,7 +416,9 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             }
         )
 
-        expected_response = make_paginated_api_response([], 0, 0, None, None)
+        expected_response = make_paginated_api_response(
+            results=[], count=0, num_pages=0, next_link=None, previous_link=None
+        )
         expected_response.update({"text_search_rewrite": None})
         self.assert_response_correct(
             response,
@@ -949,7 +953,9 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.assert_response_correct(
             response,
             200,
-            make_paginated_api_response(expected_comments, 0, 10, next_link, None)
+            make_paginated_api_response(
+                results=expected_comments, count=0, num_pages=10, next_link=next_link, previous_link=None
+            )
         )
         self.assert_query_params_equal(
             httpretty.httpretty.latest_requests[-2],

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -23,6 +23,7 @@ from discussion_api.tests.utils import (
     CommentsServiceMockMixin,
     make_minimal_cs_comment,
     make_minimal_cs_thread,
+    make_paginated_api_response
 )
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from util.testing import UrlResetMixin, PatchMediaTypeMixin
@@ -307,15 +308,18 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         }]
         self.register_get_threads_response(source_threads, page=1, num_pages=2)
         response = self.client.get(self.url, {"course_id": unicode(self.course.id), "following": ""})
+        expected_respoonse = make_paginated_api_response(
+            expected_threads,
+            0,
+            2,
+            "http://testserver/api/discussion/v1/threads/?course_id=x%2Fy%2Fz&page=2",
+            None
+        )
+        expected_respoonse.update({"text_search_rewrite": None})
         self.assert_response_correct(
             response,
             200,
-            {
-                "results": expected_threads,
-                "next": "http://testserver/api/discussion/v1/threads/?course_id=x%2Fy%2Fz&page=2",
-                "previous": None,
-                "text_search_rewrite": None,
-            }
+            expected_respoonse
         )
         self.assert_last_query_params({
             "user_id": [unicode(self.user.id)],
@@ -374,15 +378,18 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
 
     def test_text_search(self):
         self.register_get_user_response(self.user)
-        self.register_get_threads_search_response([], None)
+        self.register_get_threads_search_response([], None, num_pages=0)
         response = self.client.get(
             self.url,
             {"course_id": unicode(self.course.id), "text_search": "test search string"}
         )
+
+        expected_response = make_paginated_api_response([], 0, 0, None, None)
+        expected_response.update({"text_search_rewrite": None})
         self.assert_response_correct(
             response,
             200,
-            {"results": [], "next": None, "previous": None, "text_search_rewrite": None}
+            expected_response
         )
         self.assert_last_query_params({
             "user_id": [unicode(self.user.id)],
@@ -398,7 +405,7 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     @ddt.data(True, "true", "1")
     def test_following_true(self, following):
         self.register_get_user_response(self.user)
-        self.register_subscribed_threads_response(self.user, [], page=1, num_pages=1)
+        self.register_subscribed_threads_response(self.user, [], page=1, num_pages=0)
         response = self.client.get(
             self.url,
             {
@@ -406,10 +413,13 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
                 "following": following,
             }
         )
+
+        expected_response = make_paginated_api_response([], 0, 0, None, None)
+        expected_response.update({"text_search_rewrite": None})
         self.assert_response_correct(
             response,
             200,
-            {"results": [], "next": None, "previous": None, "text_search_rewrite": None}
+            expected_response
         )
         self.assertEqual(
             urlparse(httpretty.last_request().path).path,
@@ -933,16 +943,13 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             "resp_total": 100,
         })
         response = self.client.get(self.url, {"thread_id": self.thread_id})
+        next_link = "http://testserver/api/discussion/v1/comments/?page=2&thread_id={}".format(
+            self.thread_id
+        )
         self.assert_response_correct(
             response,
             200,
-            {
-                "results": expected_comments,
-                "next": "http://testserver/api/discussion/v1/comments/?page=2&thread_id={}".format(
-                    self.thread_id
-                ),
-                "previous": None,
-            }
+            make_paginated_api_response(expected_comments, 0, 10, next_link, None)
         )
         self.assert_query_params_equal(
             httpretty.httpretty.latest_requests[-2],

--- a/lms/djangoapps/discussion_api/tests/utils.py
+++ b/lms/djangoapps/discussion_api/tests/utils.py
@@ -71,7 +71,7 @@ class CommentsServiceMockMixin(object):
             status=200
         )
 
-    def register_get_threads_search_response(self, threads, rewrite):
+    def register_get_threads_search_response(self, threads, rewrite, num_pages=1):
         """Register a mock response for GET on the CS thread search endpoint"""
         httpretty.register_uri(
             httpretty.GET,
@@ -79,7 +79,7 @@ class CommentsServiceMockMixin(object):
             body=json.dumps({
                 "collection": threads,
                 "page": 1,
-                "num_pages": 1,
+                "num_pages": num_pages,
                 "corrected_text": rewrite,
             }),
             status=200
@@ -371,3 +371,18 @@ def make_minimal_cs_comment(overrides=None):
     }
     ret.update(overrides or {})
     return ret
+
+
+def make_paginated_api_response(results, count, num_pages, next, previous):
+    """
+    Generates the response dictionary of paginated APIs with passed data
+    """
+    return {
+        "pagination": {
+            "next": next,
+            "previous": previous,
+            "count": count,
+            "num_pages": num_pages,
+        },
+        "results": results
+    }

--- a/lms/djangoapps/discussion_api/tests/utils.py
+++ b/lms/djangoapps/discussion_api/tests/utils.py
@@ -373,7 +373,7 @@ def make_minimal_cs_comment(overrides=None):
     return ret
 
 
-def make_paginated_api_response(results, count, num_pages, next_link, previous_link):
+def make_paginated_api_response(results=[], count=0, num_pages=0, next_link=None, previous_link=None):
     """
     Generates the response dictionary of paginated APIs with passed data
     """

--- a/lms/djangoapps/discussion_api/tests/utils.py
+++ b/lms/djangoapps/discussion_api/tests/utils.py
@@ -373,14 +373,14 @@ def make_minimal_cs_comment(overrides=None):
     return ret
 
 
-def make_paginated_api_response(results, count, num_pages, next, previous):
+def make_paginated_api_response(results, count, num_pages, next_link, previous_link):
     """
     Generates the response dictionary of paginated APIs with passed data
     """
     return {
         "pagination": {
-            "next": next,
-            "previous": previous,
+            "next": next_link,
+            "previous": previous_link,
             "count": count,
             "num_pages": num_pages,
         },

--- a/lms/djangoapps/discussion_api/views.py
+++ b/lms/djangoapps/discussion_api/views.py
@@ -261,19 +261,17 @@ class ThreadViewSet(DeveloperErrorViewMixin, ViewSet):
         form = ThreadListGetForm(request.GET)
         if not form.is_valid():
             raise ValidationError(form.errors)
-        return Response(
-            get_thread_list(
-                request,
-                form.cleaned_data["course_id"],
-                form.cleaned_data["page"],
-                form.cleaned_data["page_size"],
-                form.cleaned_data["topic_id"],
-                form.cleaned_data["text_search"],
-                form.cleaned_data["following"],
-                form.cleaned_data["view"],
-                form.cleaned_data["order_by"],
-                form.cleaned_data["order_direction"],
-            )
+        return get_thread_list(
+            request,
+            form.cleaned_data["course_id"],
+            form.cleaned_data["page"],
+            form.cleaned_data["page_size"],
+            form.cleaned_data["topic_id"],
+            form.cleaned_data["text_search"],
+            form.cleaned_data["following"],
+            form.cleaned_data["view"],
+            form.cleaned_data["order_by"],
+            form.cleaned_data["order_direction"],
         )
 
     def retrieve(self, request, thread_id=None):
@@ -443,14 +441,12 @@ class CommentViewSet(DeveloperErrorViewMixin, ViewSet):
         form = CommentListGetForm(request.GET)
         if not form.is_valid():
             raise ValidationError(form.errors)
-        return Response(
-            get_comment_list(
-                request,
-                form.cleaned_data["thread_id"],
-                form.cleaned_data["endorsed"],
-                form.cleaned_data["page"],
-                form.cleaned_data["page_size"]
-            )
+        return get_comment_list(
+            request,
+            form.cleaned_data["thread_id"],
+            form.cleaned_data["endorsed"],
+            form.cleaned_data["page"],
+            form.cleaned_data["page_size"]
         )
 
     def retrieve(self, request, comment_id=None):
@@ -460,13 +456,11 @@ class CommentViewSet(DeveloperErrorViewMixin, ViewSet):
         form = _PaginationForm(request.GET)
         if not form.is_valid():
             raise ValidationError(form.errors)
-        return Response(
-            get_response_comments(
-                request,
-                comment_id,
-                form.cleaned_data["page"],
-                form.cleaned_data["page_size"]
-            )
+        return get_response_comments(
+            request,
+            comment_id,
+            form.cleaned_data["page"],
+            form.cleaned_data["page_size"]
         )
 
     def create(self, request):

--- a/openedx/core/djangoapps/content/course_structures/api/v0/api.py
+++ b/openedx/core/djangoapps/content/course_structures/api/v0/api.py
@@ -6,8 +6,9 @@ of the tricky interactions between DRF and the code.
 Most of that information is available by accessing the course objects directly.
 """
 from collections import OrderedDict
+from openedx.core.lib.exceptions import CourseNotFoundError
 from .serializers import GradingPolicySerializer, CourseStructureSerializer
-from .errors import CourseNotFoundError, CourseStructureNotAvailableError
+from .errors import CourseStructureNotAvailableError
 from openedx.core.djangoapps.content.course_structures import models, tasks
 from util.cache import cache
 from xmodule.modulestore.django import modulestore

--- a/openedx/core/djangoapps/content/course_structures/api/v0/errors.py
+++ b/openedx/core/djangoapps/content/course_structures/api/v0/errors.py
@@ -1,11 +1,6 @@
 """ Errors used by the Course Structure API. """
 
 
-class CourseNotFoundError(Exception):
-    """ The course was not found. """
-    pass
-
-
 class CourseStructureNotAvailableError(Exception):
     """ The course structure still needs to be generated. """
     pass

--- a/openedx/core/lib/api/paginators.py
+++ b/openedx/core/lib/api/paginators.py
@@ -39,6 +39,18 @@ class NamespacedPageNumberPagination(pagination.PageNumberPagination):
 
     page_size_query_param = "page_size"
 
+    def get_result_count(self):
+        """
+        Returns total number of results
+        """
+        return self.page.paginator.count
+
+    def get_num_pages(self):
+        """
+        Returns total number of pages the results are divided into
+        """
+        return self.page.paginator.num_pages
+
     def get_paginated_response(self, data):
         """
         Annotate the response with pagination information
@@ -46,8 +58,8 @@ class NamespacedPageNumberPagination(pagination.PageNumberPagination):
         metadata = {
             'next': self.get_next_link(),
             'previous': self.get_previous_link(),
-            'count': self.page.paginator.count,
-            'num_pages': self.page.paginator.num_pages,
+            'count': self.get_result_count(),
+            'num_pages': self.get_num_pages(),
         }
         if isinstance(data, dict):
             if 'results' not in data:

--- a/openedx/core/lib/api/view_utils.py
+++ b/openedx/core/lib/api/view_utils.py
@@ -2,7 +2,7 @@
 Utilities related to API views
 """
 import functools
-from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
+from django.core.exceptions import NON_FIELD_ERRORS, ValidationError, ObjectDoesNotExist
 from django.http import Http404
 from django.utils.translation import ugettext as _
 
@@ -68,7 +68,7 @@ class DeveloperErrorViewMixin(object):
 
         if isinstance(exc, APIException):
             return self.make_error_response(exc.status_code, exc.detail)
-        elif isinstance(exc, Http404):
+        elif isinstance(exc, Http404) or isinstance(exc, ObjectDoesNotExist):
             return self.make_error_response(404, exc.message or "Not found.")
         elif isinstance(exc, ValidationError):
             return self.make_validation_error_response(exc)

--- a/openedx/core/lib/exceptions.py
+++ b/openedx/core/lib/exceptions.py
@@ -1,0 +1,12 @@
+""" Common Purpose Errors"""
+from django.core.exceptions import ObjectDoesNotExist
+
+
+class CourseNotFoundError(ObjectDoesNotExist):
+    """ Course was not found. """
+    pass
+
+
+class PageNotFoundError(ObjectDoesNotExist):
+    """ Page was not found. Used for paginated endpoint. """
+    pass


### PR DESCRIPTION
### Description

TASK: [Fix the discussions in iOS App](https://app.asana.com/0/24249656184052/259727523602515/f)

The discussion was unreachable because the iOS app could not find the `count` and the `num_pages ` fields int the pagination, so I did cherry-pick the changes from edx-platform [discussion_api](https://github.com/edx/edx-platform/tree/master/lms/djangoapps/discussion_api) app.

Later on, I found that the `v1/course_topics/{}` url is returning a server error for every course that has unicode chars in the topic id, so I encoded the field in the last commit ([c9529ac](https://github.com/Edraak/edx-platform/pull/275/commits/c9529acb90cd98f314060dd328f6e431c1f28d28)) in this PR.

### Notes
- I did not modify any of the cherry-picked commit.
- Use https://jazzar.edraakbeta.org to test against.
- Feature in the mobile apps is behind a flag: `DISCUSSIONS_ENABLED`.
- I didn't add any tests.

### Testing
- [ ] Encoding.
- [ ] Unit, integration, acceptance tests as appropriate.

