### PR TITLE
Do not force English transcript if no transcript has been found

### DIFF
--- a/lms/djangoapps/mobile_api/video_outlines/serializers.py
+++ b/lms/djangoapps/mobile_api/video_outlines/serializers.py
@@ -212,7 +212,9 @@ def video_summary(video_profiles, course_id, video_descriptor, request, local_ca
 
     # Transcripts...
     transcripts_info = video_descriptor.get_transcripts_info()
-    transcript_langs = video_descriptor.available_translations(transcripts_info, verify_assets=False)
+    # Edraak (mobile): Do not force English if there's no subtitles found.
+    # transcript_langs = video_descriptor.available_translations(transcripts_info, verify_assets=False)
+    transcript_langs = video_descriptor.available_translations(transcripts_info)
 
     transcripts = {
         lang: reverse(


### PR DESCRIPTION
### Description

TASK: [Video player: Caption icon should not be displayed for the video does'nt have a transcript ](https://app.asana.com/0/inbox/35717934599876/286559698961477/286808284353863)

edX are forcing the English language in the API, I guess it's a business need so I did comment them in our repo.

### Notes
- I didn't find the relative test cases to it, so if you feel this is important and you believe there's a test case, I can rewrite it for this specific edit.
