### PR TITLE
Fixing any_unfulfilled_milestones in mobile course_enrollments API

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -53,6 +53,7 @@ from contentstore.views.entrance_exam import (
     delete_entrance_exam,
     update_entrance_exam,
 )
+from milestones import api as milestones_api
 from course_action_state.managers import CourseActionStateItemNotFoundError
 from course_action_state.models import CourseRerunState, CourseRerunUIStateManager
 from course_creators.views import get_course_creator_status, add_user_with_status_unrequested
@@ -83,6 +84,7 @@ from util.milestones_helpers import (
     is_prerequisite_courses_enabled,
     is_valid_course_key,
     set_prerequisite_courses,
+    remove_prerequisite_course,
 )
 from util.organizations_helpers import (
     add_organization_course,
@@ -1023,6 +1025,11 @@ def settings_handler(request, course_key_string):
                         if not all(is_valid_course_key(course_key) for course_key in prerequisite_course_keys):
                             return JsonResponseBadRequest({"error": _("Invalid prerequisite course key")})
                         set_prerequisite_courses(course_key, prerequisite_course_keys)
+                    else:
+                        # None is chose so remove the course prerequites
+                        course_milestones = milestones_api.get_course_milestones(course_key=course_key, relationship="requires")
+                        for milestone in course_milestones:
+                            remove_prerequisite_course(course_key, milestone)
 
                 # If the entrance exams feature has been enabled, we'll need to check for some
                 # feature-specific settings and handle them accordingly

--- a/common/djangoapps/util/milestones_helpers.py
+++ b/common/djangoapps/util/milestones_helpers.py
@@ -376,9 +376,13 @@ def any_unfulfilled_milestones(course_id, user_id):
     """ Returns a boolean if user has any unfulfilled milestones """
     if not settings.FEATURES.get('MILESTONES_APP', False):
         return False
-    return bool(
-        get_course_milestones_fulfillment_paths(course_id, {"id": user_id})
-    )
+
+    from milestones import api as milestones_api
+    fulfillment_paths = milestones_api.get_course_milestones_fulfillment_paths(course_id, {'id': user_id})
+
+    # Returns True if any of the milestones is unfulfilled. False if
+    # values is empty or all values are.
+    return any(fulfillment_paths.values())
 
 
 def get_course_milestones_fulfillment_paths(course_id, user_id):


### PR DESCRIPTION
### Description

In [User Course Enrollments List](https://courses.edx.org/api/mobile/v0.5/users/<username>/course_enrollments), if we enabled **Entrance Exam** from _Schedule & Details_ section and then re-desabling it, the`courseware_access` field in the API will keep preventing the student from showing the course on the mobile apps. 

```JSON
            "courseware_access": {
                "has_access": false,
                "error_code": "unfulfilled_milestones",
                "developer_message": "User has unfulfilled milestones",
                "user_message": "User has unfulfilled milestones."
            },
```

This problem is happening because the `get_course_milestones_fulfillment_paths` method in the [milestones API](https://github.com/edx/edx-milestones/blob/master/milestones/api.py#L176) is returning an empty dictionary `{}` if the course doesn't have any milestones, after enabling *Entrance Exam*  it returns a complex dict-of-dicts like this:

```JSON
{
  "course-v1:org+course+run.entrance_exams.Completed Course Entrance Exam": {
     "content": [
          "block-v1:org+course+run+type@chapter+block@cd5f1b8bef874bcdad80b2857f5aeffd"
     ]
  }
}
```

While redoubling the entrance exam causes the method to return the previously-enabled prerequisites with an empty dictionary like this:

```JSON
{"course-v1:org+course+run.entrance_exams.Completed Course Entrance Exam": {}}
```

The method `any_unfulfilled_milestones` is not addressing this scenario, so what I did is checking that every value in the dict returned from `get_course_milestones_fulfillment_paths`, if any value has a non-empty dictionary then the student is still having unfulfilled milestones and we are returning `True`, if the dictionary is empty or the student have fulfilled the milestones then we are returning `False`.

## Notes
1. This solution won't affect the result if the learner completed the prerequisites since the `get_course_milestones_fulfillment_paths` will return an empty dictionary if the **Entrance Exam** fulfilled.
2. EdX PR: [#14758](https://github.com/edx/edx-platform/pull/14758)


Update
=====
Another issue arised as if the instructor enabled and disabled the **Prerequisite Course** in _Studio_'s Requirements section, the course became inaccessible for learner in the _dashboard_ and the _API_ views.
This happens because selecting **None** from the _dropdown_ list in _Studio_ has no functionality in the code.
