### PR TITLE
Hiding calculator from the mobile view

### DIFF
--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -97,15 +97,10 @@ ${fragment.foot_html()}
   </section>
 </div>
 
-<nav class="nav-utilities ${"has-utility-calculator" if course.show_calculator else ""}" aria-label="${_('Course Utilities')}">
+<nav class="nav-utilities" aria-label="${_('Course Utilities')}">
   ## Utility: Notes
   % if is_edxnotes_enabled(course):
     <%include file="/edxnotes/toggle_notes.html" args="course=course"/>
-  % endif
-
-  ## Utility: Calc
-  % if course.show_calculator:
-    <%include file="/calculator/toggle_calculator.html" />
   % endif
 </nav>
 


### PR DESCRIPTION
### Description

TASK: [iOS/ Calculator:  The hint popup design is displayed improperly, Moreover the user is not being able to exit the popup window. ](https://app.asana.com/0/inbox/35717934599876/304427582953119/314046083441849)

We are hiding the calculator in all mobile views regardless of the course settings.