### PR TITLE
Do not force English transcript if no transcript has been found

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -855,7 +855,9 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
         transcripts_info = self.get_transcripts_info()
         transcripts = {
             lang: self.runtime.handler_url(self, 'transcript', 'download', query="lang=" + lang, thirdparty=True)
-            for lang in self.available_translations(transcripts_info, verify_assets=False)
+            # Edraak (mobile): Do not force English if there's no subtitles found.
+            # for lang in self.available_translations(transcripts_info, verify_assets=False)
+            for lang in self.available_translations(transcripts_info)
         }
 
         return {


### PR DESCRIPTION
### Description

TASK: [Video player: Caption icon should not be displayed for the video does'nt have a transcript ](https://app.asana.com/0/inbox/35717934599876/286559698961477/286808284353863)

Yes, this fixes the same issue #279 did, the problem here is that the application is talking with different end points to fetch certain data of the blocks. The solution here is covering the other part of the API.