### PR TITLE
update insecure old ugifyjs version SEC CVE-2015-8858

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-This is the main edX platform which consists of LMS and Studio.
+This is the main edX platform which consists of LMS and Studio (Dogwood release)
 
 
 Installation

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "dependencies": {
     "coffee-script": "1.6.1",
-    "uglify-js": "2.4.24"
+    "uglify-js": "2.6.4"
   },
   "devDependencies": {
     "jshint": "^2.7.0",


### PR DESCRIPTION
### Description

Critical sec issue in ver 2.4 https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8858