### PR TITLE
Customize the enrollment api to return the courses detail description

### DIFF
--- a/common/djangoapps/enrollment/api.py
+++ b/common/djangoapps/enrollment/api.py
@@ -17,7 +17,8 @@ log = logging.getLogger(__name__)
 DEFAULT_DATA_API = 'enrollment.data'
 
 
-def get_enrollments(user_id):
+# Edraak: update function to accept request param
+def get_enrollments(user_id, request=None):
     """Retrieves all the courses a user is enrolled in.
 
     Takes a user and retrieves all relative enrollments. Includes information regarding how the user is enrolled
@@ -87,10 +88,12 @@ def get_enrollments(user_id):
         ]
 
     """
-    return _data_api().get_course_enrollments(user_id)
+    # Edraak: pass request param to _data_api().get_course_enrollments
+    return _data_api().get_course_enrollments(user_id, request=request)
 
 
-def get_enrollment(user_id, course_id):
+# Edraak: update function to accept request param
+def get_enrollment(user_id, course_id, request=None):
     """Retrieves all enrollment information for the user in respect to a specific course.
 
     Gets all the course enrollment information specific to a user in a course.
@@ -132,7 +135,8 @@ def get_enrollment(user_id, course_id):
         }
 
     """
-    return _data_api().get_course_enrollment(user_id, course_id)
+    return _data_api().get_course_enrollment(user_id, course_id,
+                                             request=request)
 
 
 def add_enrollment(user_id, course_id, mode=None, is_active=True):

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -172,7 +172,9 @@ class EnrollmentView(APIView, ApiKeyPermissionMixIn):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         try:
-            return Response(api.get_enrollment(username, course_id))
+            # Edraak: pass request to api.get_enrollment
+            return Response(api.get_enrollment(username, course_id,
+                                               request=request))
         except CourseEnrollmentError:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
@@ -475,7 +477,8 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
         """
         username = request.GET.get('user', request.user.username)
         try:
-            enrollment_data = api.get_enrollments(username)
+            # Edraak: pass request to api.get_enrollments
+            enrollment_data = api.get_enrollments(username, request)
         except CourseEnrollmentError:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,

--- a/lms/djangoapps/edraak_misc/constants.py
+++ b/lms/djangoapps/edraak_misc/constants.py
@@ -1,0 +1,2 @@
+COURSE_MKTG_DETAILS_CACHE_KEY =\
+    u'enrollment.course.marketing.details.{course_id}'


### PR DESCRIPTION
This PR adds extra information (course information) to the edx platform enrollment API endpoint's returned result.

2 new attribute `edraak_course_details` and `is_certificate_allowed ` are now returned ex:
```json
{
      ...
      "edraak_course_details": {
            "blocks_url": "http://courses.edraak.dw/api/courses/v1/blocks/?course_id=co...",
            "course_id": "course-v1:UniversityOfJordan+BIN101+T1_2018",
            ...
        },
        "is_certificate_allowed": false,
      ...
}
```

`edraak_course_details` is the same as the course description returned in the courses api endpoint.
`is_certificate_allowed ` represents wether or not this user should be able to access the issue certificate link for this course at this time.

 these changes are important for supporting the dashboard on the programs platform as well as the specializations feature.

**Depends on**
- marketing PR [134](https://github.com/Edraak/marketing-site/pull/134)