### PR TITLE
add a link to the header of course that are part of a specialization …

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1255,9 +1255,9 @@ def advanced_settings_handler(request, course_key_string):
                             spec_json = r.json()
                             CourseSpecializationInfo.objects.update_or_create(
                                 course_id=course_key,
-                                specialization_slug=
-                                course_module.specialization_slug,
                                 defaults={
+                                    'specialization_slug':
+                                        course_module.specialization_slug,
                                     'name_en': spec_json.get('name_en'),
                                     'name_ar': spec_json.get('name_ar')
                                 }

--- a/common/djangoapps/edraak_specializations/admin.py
+++ b/common/djangoapps/edraak_specializations/admin.py
@@ -1,0 +1,14 @@
+from django.contrib import admin
+
+from .models import CourseSpecializationInfo
+
+
+class SpecializationAdmin(admin.ModelAdmin):
+    list_display = (
+        'course_id',
+        'name_ar',
+        'name_en',
+    )
+    readonly_fields = ('name_ar', 'name_en',)
+
+admin.site.register(CourseSpecializationInfo, SpecializationAdmin)

--- a/common/djangoapps/edraak_specializations/helpers.py
+++ b/common/djangoapps/edraak_specializations/helpers.py
@@ -32,9 +32,9 @@ def get_specialization_info(course_id):
     info["title"] = info_obj.name_en if get_language() == "en"\
         else info_obj.name_ar
     info["link"] = urljoin(
-        settings.PROGS_URLS.get('ROOT'),
-        settings.PROGS_URLS.get("PROG_LMS", "").format(
-            program_slug=info_obj.specialization_slug
+        settings.MKTG_URLS.get('ROOT'),
+        settings.MKTG_URLS.get("SPECIALIZATION_INFO", "").format(
+            slug=info_obj.specialization_slug
         )
     )
     return info


### PR DESCRIPTION
## Description
Make the specialization title the courseware header link back to the specialization info page on the marketing page.

## Also add:
- add `CourseSpecializationInfo` to the admin panel.
- limit adding a course to one specialization on a database level.

## Related PRs:
- depends on the configurations [PR 54](https://github.com/Edraak/configuration/pull/54) 