### PR TITLE
pass request to enrollment api functions

### DIFF
--- a/common/djangoapps/enrollment/api.py
+++ b/common/djangoapps/enrollment/api.py
@@ -141,7 +141,8 @@ def get_enrollment(user_id, course_id, request=None):
                                              request=request)
 
 
-def add_enrollment(user_id, course_id, mode=None, is_active=True):
+def add_enrollment(user_id, course_id, mode=None, is_active=True,
+                   request=None):
     """Enrolls a user in a course.
 
     Enrolls a user in a course. If the mode is not specified, this will default to `CourseMode.DEFAULT_MODE_SLUG`.
@@ -191,7 +192,9 @@ def add_enrollment(user_id, course_id, mode=None, is_active=True):
     if mode is None:
         mode = _default_course_mode(course_id)
     _validate_course_mode(course_id, mode, is_active=is_active)
-    return _data_api().create_course_enrollment(user_id, course_id, mode, is_active)
+    return _data_api().create_course_enrollment(user_id, course_id,
+                                                mode, is_active,
+                                                request=request)
 
 
 def update_enrollment(user_id, course_id, mode=None, is_active=None, enrollment_attributes=None):

--- a/common/djangoapps/enrollment/data.py
+++ b/common/djangoapps/enrollment/data.py
@@ -117,7 +117,8 @@ def get_course_enrollment(username, course_id, request=None):
         return None
 
 
-def create_course_enrollment(username, course_id, mode, is_active):
+def create_course_enrollment(username, course_id, mode, is_active,
+                             request=None):
     """Create a new course enrollment for the given user.
 
     Creates a new course enrollment for the specified user username.
@@ -157,7 +158,8 @@ def create_course_enrollment(username, course_id, mode, is_active):
     except CourseFullError as err:
         raise CourseEnrollmentFullError(err.message)
     except AlreadyEnrolledError as err:
-        enrollment = get_course_enrollment(username, course_id)
+        enrollment = get_course_enrollment(username, course_id,
+                                           request=request)
         raise CourseEnrollmentExistsError(err.message, enrollment)
 
 

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -612,7 +612,9 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
                 )
             else:
                 # Will reactivate inactive enrollments.
-                response = api.add_enrollment(username, unicode(course_id), mode=mode, is_active=is_active)
+                response = api.add_enrollment(username, unicode(
+                    course_id), mode=mode, is_active=is_active,
+                                              request=request)
 
             email_opt_in = request.data.get('email_opt_in', None)
             if email_opt_in is not None:


### PR DESCRIPTION
### Description

serializing the course enrollment when enrolling in a  course that the user had already enrolled in was resulting in a 500 error because the add_enrollment api endpoint was not receiving the request parameter.