### PR TITLE
enrollment api endpoint has been updated to accept trailing forward slashes

### DIFF
--- a/common/djangoapps/enrollment/urls.py
+++ b/common/djangoapps/enrollment/urls.py
@@ -22,7 +22,7 @@ urlpatterns = patterns(
         name='courseenrollment'
     ),
     url(
-        r'^enrollment/{course_key}$'.format(course_key=settings.COURSE_ID_PATTERN),
+        r'^enrollment/{course_key}'.format(course_key=settings.COURSE_ID_PATTERN),
         EnrollmentView.as_view(),
         name='courseenrollment'
     ),


### PR DESCRIPTION
### Description
This PR updates the enrollment detail API endpoint url pattern to accept trailing forward slashes `/` similar to the course details API endpoint.

The effect of this will reflect on specializations on the programs platform. 
Previously when adding a course to a specialization by Id with an extra forward slash at the end of the id the course was saving correctly because that would still be a valid course id and when calling the course details API to get the courses details the API responds correctly because it accepts trailing forward slashes.

This was causing an issue on the LMS page of specializations on the progs platform. because the course_id is saved with a trailing forward slash and when the enrollment details API is called for a student it will not accept extra trailing forward slashes.

I've decided to remove the `$` from the end of the url pattern instead of adding an expression to accept an extra `/` because I want it to be similar to the course detail api.