### PR TITLE
Revert "enrollment api endpoint has been updated to accept trailing forward slashes"

### DIFF
--- a/common/djangoapps/enrollment/urls.py
+++ b/common/djangoapps/enrollment/urls.py
@@ -22,7 +22,7 @@ urlpatterns = patterns(
         name='courseenrollment'
     ),
     url(
-        r'^enrollment/{course_key}'.format(course_key=settings.COURSE_ID_PATTERN),
+        r'^enrollment/{course_key}$'.format(course_key=settings.COURSE_ID_PATTERN),
         EnrollmentView.as_view(),
         name='courseenrollment'
     ),


### PR DESCRIPTION
Reverts Edraak/edx-platform#327

After a discussion we had in the previous stand ups. we have decided to revert the change in the [PR 327](https://github.com/Edraak/edx-platform/pull/327).
The suggested approach by sherif to solve the issue that [PR 327](https://github.com/Edraak/edx-platform/pull/327) resolves is to add a validator on the progs platform to validate course ids when added to a specializations to make sure they do not contain leading or trailing forward slashes `/`
The needed changes have been pushed in the following progs platform [PR](https://github.com/Edraak/edraak-programs/pull/261)
