### PR TITLE
set facebook auth_type to the needed value to refresh expired tokens

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -693,7 +693,7 @@ SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = {
   'fields': 'id, name, email'
 }
 SOCIAL_AUTH_FACEBOOK_AUTH_EXTRA_ARGUMENTS = {
-    'auth_type': 'rerequest',
+    'auth_type': 'reauthorize',
 }
 
 XBLOCK_SETTINGS = ENV_TOKENS.get('XBLOCK_SETTINGS', {})


### PR DESCRIPTION
### Description

This change patches the auth_type defined in the previous [PR 331](https://github.com/Edraak/edx-platform/pull/331). which was spoused to be `reauthorize` not `rerequest` 