### PR TITLE
Fixes redirection to other origin (mktg/progs) after logistration

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -286,7 +286,7 @@ def enroll(user, course_id, request, check_access):
 
 # Query string parameters that can be passed to the "finish_auth" view to manage
 # things like auto-enrollment.
-POST_AUTH_PARAMS = ('course_id', 'enrollment_action', 'course_mode', 'email_opt_in')
+POST_AUTH_PARAMS = ('course_id', 'enrollment_action', 'course_mode', 'email_opt_in', 'next_origin')
 
 
 def get_next_url_for_login_page(request):


### PR DESCRIPTION
### Description
After logistration using third party authentication if the next origin of the next url is outside `edx-platform` it will return `404` page not found.

### Related PRs
https://github.com/Edraak/marketing-site/pull/251