### PR TITLE
Fixes django 1.8 & 1.11 incompatible csrf issue

### DIFF
--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -5,7 +5,7 @@ import json
 
 from django.http import HttpResponseBadRequest
 from django.contrib.auth.decorators import login_required
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods, require_POST
 from django.conf import settings
 

--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -25,7 +25,7 @@ import json
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from django.http import HttpResponse
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_http_methods

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -18,7 +18,7 @@ from django.shortcuts import redirect
 import django.utils
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_http_methods, require_GET
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locations import Location

--- a/cms/djangoapps/contentstore/views/entrance_exam.py
+++ b/cms/djangoapps/contentstore/views/entrance_exam.py
@@ -7,7 +7,7 @@ import json
 import logging
 
 from django.contrib.auth.decorators import login_required
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from django.http import HttpResponse, HttpResponseBadRequest
 
 from openedx.core.lib.js_utils import escape_json_dumps

--- a/cms/djangoapps/contentstore/views/export_git.py
+++ b/cms/djangoapps/contentstore/views/export_git.py
@@ -7,7 +7,7 @@ import logging
 
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from django.utils.translation import ugettext as _
 
 from student.auth import has_course_author_access

--- a/cms/djangoapps/contentstore/views/import_export.py
+++ b/cms/djangoapps/contentstore/views/import_export.py
@@ -18,7 +18,7 @@ from django.core.files.temp import NamedTemporaryFile
 from django.core.servers.basehttp import FileWrapper
 from django.http import HttpResponse, HttpResponseNotFound
 from django.utils.translation import ugettext as _
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods, require_GET
 
 import dogstats_wrapper as dog_stats_api

--- a/cms/djangoapps/contentstore/views/library.py
+++ b/cms/djangoapps/contentstore/views/library.py
@@ -16,7 +16,7 @@ from django.core.exceptions import PermissionDenied
 from django.conf import settings
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_http_methods
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from edxmako.shortcuts import render_to_response
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey

--- a/cms/djangoapps/contentstore/views/public.py
+++ b/cms/djangoapps/contentstore/views/public.py
@@ -1,9 +1,9 @@
 """
 Public views
 """
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from django.views.decorators.clickjacking import xframe_options_deny
-from django.core.context_processors import csrf
+from edraak_backends.context_processors import csrf
 from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
 from django.conf import settings

--- a/cms/djangoapps/contentstore/views/tabs.py
+++ b/cms/djangoapps/contentstore/views/tabs.py
@@ -7,7 +7,7 @@ from util.json_request import expect_json, JsonResponse
 from django.http import HttpResponseNotFound
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods
 
 from edxmako.shortcuts import render_to_response

--- a/cms/djangoapps/contentstore/views/user.py
+++ b/cms/djangoapps/contentstore/views/user.py
@@ -4,7 +4,7 @@ from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_http_methods
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from edxmako.shortcuts import render_to_response
 
 from xmodule.modulestore.django import modulestore

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -305,7 +305,7 @@ MIDDLEWARE_CLASSES = (
     'request_cache.middleware.RequestCache',
     'django.middleware.cache.UpdateCacheMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
+    'edraak_backends.middleware.EdraakCsrfViewMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'method_override.middleware.MethodOverrideMiddleware',
 

--- a/common/djangoapps/auth_exchange/views.py
+++ b/common/djangoapps/auth_exchange/views.py
@@ -12,7 +12,7 @@ from django.contrib.auth import login
 import django.contrib.auth as auth
 from django.http import HttpResponse
 from django.utils.decorators import method_decorator
-from django.views.decorators.csrf import csrf_exempt
+from edraak_backends.csrf import csrf_exempt
 from provider import constants
 from provider.oauth2.views import AccessTokenView as AccessTokenView
 from rest_framework import permissions

--- a/common/djangoapps/cors_csrf/decorators.py
+++ b/common/djangoapps/cors_csrf/decorators.py
@@ -1,5 +1,5 @@
 """Decorators for cross-domain CSRF. """
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 
 
 def ensure_csrf_cookie_cross_domain(func):

--- a/common/djangoapps/cors_csrf/middleware.py
+++ b/common/djangoapps/cors_csrf/middleware.py
@@ -45,7 +45,7 @@ CSRF cookie.
 import logging
 
 from django.conf import settings
-from django.middleware.csrf import CsrfViewMiddleware
+from edraak_backends.middleware import EdraakCsrfViewMiddleware
 from django.core.exceptions import MiddlewareNotUsed, ImproperlyConfigured
 
 from cors_csrf.helpers import is_cross_domain_request_allowed, skip_cross_domain_referer_check
@@ -53,7 +53,7 @@ from cors_csrf.helpers import is_cross_domain_request_allowed, skip_cross_domain
 log = logging.getLogger(__name__)
 
 
-class CorsCSRFMiddleware(CsrfViewMiddleware):
+class CorsCSRFMiddleware(EdraakCsrfViewMiddleware):
     """
     Middleware for handling CSRF checks with CORS requests
     """

--- a/common/djangoapps/cors_csrf/tests/test_middleware.py
+++ b/common/djangoapps/cors_csrf/tests/test_middleware.py
@@ -9,7 +9,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.core.exceptions import MiddlewareNotUsed, ImproperlyConfigured
 from django.http import HttpResponse
-from django.middleware.csrf import CsrfViewMiddleware
+from edraak_backends.csrf import EdraakCsrfViewMiddleware
 
 from cors_csrf.middleware import CorsCSRFMiddleware, CsrfCrossDomainCookieMiddleware
 
@@ -39,7 +39,7 @@ class TestCorsMiddlewareProcessRequest(TestCase):
         """
         Check that the middleware does NOT process the provided request
         """
-        with patch.object(CsrfViewMiddleware, 'process_view') as mock_method:
+        with patch.object(EdraakCsrfViewMiddleware, 'process_view') as mock_method:
             res = self.middleware.process_view(request, None, None, None)
 
         self.assertIsNone(res)
@@ -56,7 +56,7 @@ class TestCorsMiddlewareProcessRequest(TestCase):
             self.assertFalse(request.is_secure())
             return SENTINEL
 
-        with patch.object(CsrfViewMiddleware, 'process_view') as mock_method:
+        with patch.object(EdraakCsrfViewMiddleware, 'process_view') as mock_method:
             mock_method.side_effect = cb_check_req_is_secure_false
             res = self.middleware.process_view(request, None, None, None)
 

--- a/common/djangoapps/edraak_backends/context_processors.py
+++ b/common/djangoapps/edraak_backends/context_processors.py
@@ -1,0 +1,23 @@
+from django.middleware.csrf import get_token
+from django.utils import six
+from django.utils.encoding import smart_text
+from django.utils.functional import lazy
+
+
+def csrf(request):
+    """
+    Context processor that provides a CSRF token, or the string 'NOTPROVIDED' if
+    it has not been provided by either a view decorator or the middleware
+    """
+    def _get_val():
+        token = get_token(request)
+        if token is None:
+            # In order to be able to provide debugging info in the
+            # case of misconfiguration, we use a sentinel value
+            # instead of returning an empty dict.
+            return 'NOTPROVIDED'
+        else:
+            return smart_text(token)
+    _get_val = lazy(_get_val, six.text_type)
+
+    return {'csrf_token': _get_val()}

--- a/common/djangoapps/edraak_backends/csrf.py
+++ b/common/djangoapps/edraak_backends/csrf.py
@@ -1,0 +1,60 @@
+from .middleware import EdraakCsrfViewMiddleware, get_token
+from functools import wraps
+from django.utils.decorators import available_attrs, decorator_from_middleware
+
+
+csrf_protect = decorator_from_middleware(EdraakCsrfViewMiddleware)
+csrf_protect.__name__ = "csrf_protect"
+csrf_protect.__doc__ = """
+This decorator adds CSRF protection in exactly the same way as
+EdraakCsrfViewMiddleware, but it can be used on a per view basis.  Using both, or
+using the decorator multiple times, is harmless and efficient.
+"""
+
+
+class _EnsureCsrfToken(EdraakCsrfViewMiddleware):
+    # We need this to behave just like the EdraakCsrfViewMiddleware, but not reject
+    # requests or log warnings.
+    def _reject(self, request, reason):
+        return None
+
+
+requires_csrf_token = decorator_from_middleware(_EnsureCsrfToken)
+requires_csrf_token.__name__ = 'requires_csrf_token'
+requires_csrf_token.__doc__ = """
+Use this decorator on views that need a correct csrf_token available to
+RequestContext, but without the CSRF protection that csrf_protect
+enforces.
+"""
+
+
+class _EnsureCsrfCookie(EdraakCsrfViewMiddleware):
+    def _reject(self, request, reason):
+        return None
+
+    def process_view(self, request, callback, callback_args, callback_kwargs):
+        retval = super(_EnsureCsrfCookie, self).process_view(request, callback, callback_args, callback_kwargs)
+        # Forces process_response to send the cookie
+        get_token(request)
+        return retval
+
+
+ensure_csrf_cookie = decorator_from_middleware(_EnsureCsrfCookie)
+ensure_csrf_cookie.__name__ = 'ensure_csrf_cookie'
+ensure_csrf_cookie.__doc__ = """
+Use this decorator to ensure that a view sets a CSRF cookie, whether or not it
+uses the csrf_token template tag, or the CsrfViewMiddleware is used.
+"""
+
+
+def csrf_exempt(view_func):
+    """
+    Marks a view function as being exempt from the CSRF view protection.
+    """
+    # We could just do view_func.csrf_exempt = True, but decorators
+    # are nicer if they don't have side-effects, so we return a new
+    # function.
+    def wrapped_view(*args, **kwargs):
+        return view_func(*args, **kwargs)
+    wrapped_view.csrf_exempt = True
+    return wraps(view_func, assigned=available_attrs(view_func))(wrapped_view)

--- a/common/djangoapps/edraak_backends/middleware.py
+++ b/common/djangoapps/edraak_backends/middleware.py
@@ -1,0 +1,161 @@
+"""
+This middleware inherits from Django CsrfViewMiddleware and overrides CSRF_TOKEN_LENGTH to be 64
+"""
+
+import re
+
+from django.conf import settings
+from django.core.urlresolvers import get_callable
+from django.middleware.csrf import CsrfViewMiddleware
+from django.utils.crypto import constant_time_compare, get_random_string
+from django.utils.encoding import force_text
+from django.utils.http import same_origin
+
+
+REASON_NO_REFERER = "Referer checking failed - no Referer."
+REASON_BAD_REFERER = "Referer checking failed - %s does not match %s."
+REASON_NO_CSRF_COOKIE = "CSRF cookie not set."
+REASON_BAD_TOKEN = "CSRF token missing or incorrect."
+
+CSRF_SECRET_LENGTH = 32
+CSRF_TOKEN_LENGTH = 2 * CSRF_SECRET_LENGTH
+
+
+def _get_failure_view():
+    """
+    Returns the view to be used for CSRF rejections
+    """
+    return get_callable(settings.CSRF_FAILURE_VIEW)
+
+
+def _get_new_csrf_key():
+    return get_random_string(CSRF_TOKEN_LENGTH)
+
+
+def get_token(request):
+    """
+    Returns the CSRF token required for a POST form. The token is an
+    alphanumeric value.
+
+    A side effect of calling this function is to make the csrf_protect
+    decorator and the CsrfViewMiddleware add a CSRF cookie and a 'Vary: Cookie'
+    header to the outgoing response.  For this reason, you may need to use this
+    function lazily, as is done by the csrf context processor.
+    """
+    request.META["CSRF_COOKIE_USED"] = True
+    return request.META.get("CSRF_COOKIE", None)
+
+
+def rotate_token(request):
+    """
+    Changes the CSRF token in use for a request - should be done on login
+    for security purposes.
+    """
+    request.META.update({
+        "CSRF_COOKIE_USED": True,
+        "CSRF_COOKIE": _get_new_csrf_key(),
+    })
+
+
+def _sanitize_token(token):
+    # Allow only alphanum
+    if len(token) > CSRF_TOKEN_LENGTH:
+        return _get_new_csrf_key()
+    token = re.sub('[^a-zA-Z0-9]+', '', force_text(token))
+    if token == "":
+        # In case the cookie has been truncated to nothing at some point.
+        return _get_new_csrf_key()
+    return token
+
+
+class EdraakCsrfViewMiddleware(CsrfViewMiddleware):
+
+    def process_view(self, request, callback, callback_args, callback_kwargs):
+
+        if getattr(request, 'csrf_processing_done', False):
+            return None
+
+        try:
+            csrf_token = _sanitize_token(
+                request.COOKIES[settings.CSRF_COOKIE_NAME])
+            # Use same token next time
+            request.META['CSRF_COOKIE'] = csrf_token
+        except KeyError:
+            csrf_token = None
+            # Generate token and store it in the request, so it's
+            # available to the view.
+            request.META["CSRF_COOKIE"] = _get_new_csrf_key()
+
+        # Wait until request.META["CSRF_COOKIE"] has been manipulated before
+        # bailing out, so that get_token still works
+        if getattr(callback, 'csrf_exempt', False):
+            return None
+
+        # Assume that anything not defined as 'safe' by RFC2616 needs protection
+        if request.method not in ('GET', 'HEAD', 'OPTIONS', 'TRACE'):
+            if getattr(request, '_dont_enforce_csrf_checks', False):
+                # Mechanism to turn off CSRF checks for test suite.
+                # It comes after the creation of CSRF cookies, so that
+                # everything else continues to work exactly the same
+                # (e.g. cookies are sent, etc.), but before any
+                # branches that call reject().
+                return self._accept(request)
+
+            if request.is_secure():
+                # Suppose user visits http://example.com/
+                # An active network attacker (man-in-the-middle, MITM) sends a
+                # POST form that targets https://example.com/detonate-bomb/ and
+                # submits it via JavaScript.
+                #
+                # The attacker will need to provide a CSRF cookie and token, but
+                # that's no problem for a MITM and the session-independent
+                # nonce we're using. So the MITM can circumvent the CSRF
+                # protection. This is true for any HTTP connection, but anyone
+                # using HTTPS expects better! For this reason, for
+                # https://example.com/ we need additional protection that treats
+                # http://example.com/ as completely untrusted. Under HTTPS,
+                # Barth et al. found that the Referer header is missing for
+                # same-domain requests in only about 0.2% of cases or less, so
+                # we can use strict Referer checking.
+                referer = force_text(
+                    request.META.get('HTTP_REFERER'),
+                    strings_only=True,
+                    errors='replace'
+                )
+                if referer is None:
+                    return self._reject(request, REASON_NO_REFERER)
+
+                # Note that request.get_host() includes the port.
+                good_referer = 'https://%s/' % request.get_host()
+                if not same_origin(referer, good_referer):
+                    reason = REASON_BAD_REFERER % (referer, good_referer)
+                    return self._reject(request, reason)
+
+            if csrf_token is None:
+                # No CSRF cookie. For POST requests, we insist on a CSRF cookie,
+                # and in this way we can avoid all CSRF attacks, including login
+                # CSRF.
+                return self._reject(request, REASON_NO_CSRF_COOKIE)
+
+            # Check non-cookie token for match.
+            request_csrf_token = ""
+            if request.method == "POST":
+                try:
+                    request_csrf_token = request.POST.get('csrfmiddlewaretoken', '')
+                except IOError:
+                    # Handle a broken connection before we've completed reading
+                    # the POST data. process_view shouldn't raise any
+                    # exceptions, so we'll ignore and serve the user a 403
+                    # (assuming they're still listening, which they probably
+                    # aren't because of the error).
+                    pass
+
+            if request_csrf_token == "":
+                # Fall back to X-CSRFToken, to make things easier for AJAX,
+                # and possible for PUT/DELETE.
+                request_csrf_token = request.META.get('HTTP_X_CSRFTOKEN', '')
+
+            if not constant_time_compare(request_csrf_token, csrf_token):
+                return self._reject(request, REASON_BAD_TOKEN)
+
+        return self._accept(request)

--- a/common/djangoapps/edraak_i18n/views.py
+++ b/common/djangoapps/edraak_i18n/views.py
@@ -3,7 +3,7 @@ from django.conf import settings
 
 from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
 from django.utils.translation import check_for_language
-from django.views.decorators.csrf import csrf_exempt
+from edraak_backends.csrf import csrf_exempt
 
 from django.utils.translation import LANGUAGE_SESSION_KEY
 from dark_lang import DARK_LANGUAGE_KEY

--- a/common/djangoapps/external_auth/views.py
+++ b/common/djangoapps/external_auth/views.py
@@ -31,11 +31,7 @@ from django.shortcuts import redirect
 from django.utils.translation import ugettext as _
 
 from edxmako.shortcuts import render_to_response, render_to_string
-try:
-    from django.views.decorators.csrf import csrf_exempt
-except ImportError:
-    from django.contrib.csrf.middleware import csrf_exempt
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie, csrf_exempt
 
 import django_openid_auth.views as openid_views
 from django_openid_auth import auth as openid_auth

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -18,7 +18,7 @@ from django.contrib.auth.models import User, AnonymousUser
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import password_reset_confirm
 from django.contrib import messages
-from django.core.context_processors import csrf
+from edraak_backends.context_processors import csrf
 from django.core import mail
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.core.validators import validate_email, ValidationError
@@ -30,7 +30,7 @@ from django.utils.encoding import force_bytes, force_text
 from django.utils.translation import ungettext
 from django.utils.http import base36_to_int, urlsafe_base64_encode
 from django.utils.translation import ugettext as _, get_language
-from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
+from edraak_backends.csrf import csrf_exempt, ensure_csrf_cookie
 from django.views.decorators.http import require_POST, require_GET
 from django.db.models.signals import post_save
 from django.dispatch import receiver

--- a/common/djangoapps/third_party_auth/views.py
+++ b/common/djangoapps/third_party_auth/views.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseServerError, Http404, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
-from django.views.decorators.csrf import csrf_exempt
+from edraak_backends.csrf import csrf_exempt
 import social
 from social.apps.django_app.views import complete
 from social.apps.django_app.utils import load_strategy, load_backend

--- a/common/djangoapps/track/views/__init__.py
+++ b/common/djangoapps/track/views/__init__.py
@@ -7,7 +7,7 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.shortcuts import redirect
 
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 
 from edxmako.shortcuts import render_to_response
 from ipware.ip import get_ip

--- a/common/djangoapps/track/views/segmentio.py
+++ b/common/djangoapps/track/views/segmentio.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.http import HttpResponse
 from django.views.decorators.http import require_POST
-from django.views.decorators.csrf import csrf_exempt
+from edraak_backends.csrf import csrf_exempt
 
 from eventtracking import tracker
 from opaque_keys.edx.keys import CourseKey

--- a/common/djangoapps/util/views.py
+++ b/common/djangoapps/util/views.py
@@ -6,7 +6,7 @@ from functools import wraps
 from django.conf import settings
 from django.core.cache import caches
 from django.core.validators import ValidationError, validate_email
-from django.views.decorators.csrf import requires_csrf_token
+from edraak_backends.csrf import requires_csrf_token
 from django.views.defaults import server_error
 from django.http import (Http404, HttpResponse, HttpResponseNotAllowed,
                          HttpResponseServerError)

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -9,7 +9,7 @@ from django.views.decorators.cache import cache_control
 from django.http import HttpResponse, Http404
 from django.utils import translation
 from django.shortcuts import redirect
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from django.contrib.staticfiles.storage import staticfiles_storage
 
 from edxmako.shortcuts import render_to_response

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -26,7 +26,7 @@ from django.http import Http404
 from django.shortcuts import redirect
 from django.utils.translation import ugettext as _
 from django.views.decorators.cache import cache_control
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from django.contrib.auth.models import User
 
 from courseware.courses import get_course_by_id

--- a/lms/djangoapps/certificates/views/xqueue.py
+++ b/lms/djangoapps/certificates/views/xqueue.py
@@ -7,7 +7,7 @@ import logging
 from django.contrib.auth.models import User
 from django.db import transaction
 from django.http import HttpResponse, Http404, HttpResponseForbidden
-from django.views.decorators.csrf import csrf_exempt
+from edraak_backends.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 import dogstats_wrapper as dog_stats_api
 

--- a/lms/djangoapps/commerce/views.py
+++ b/lms/djangoapps/commerce/views.py
@@ -3,7 +3,7 @@ import logging
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.views.decorators.csrf import csrf_exempt
+from edraak_backends.csrf import csrf_exempt
 
 from edxmako.shortcuts import render_to_response
 from microsite_configuration import microsite

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -16,12 +16,12 @@ import dogstats_wrapper as dog_stats_api
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.core.context_processors import csrf
+from edraak_backends.context_processors import csrf
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponse
 from django.test.client import RequestFactory
-from django.views.decorators.csrf import csrf_exempt
+from edraak_backends.csrf import csrf_exempt
 from django.utils.translation import ugettext_noop
 
 import newrelic.agent

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from django.utils.translation import ugettext as _
 
 from django.conf import settings
-from django.core.context_processors import csrf
+from edraak_backends.context_processors import csrf
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User, AnonymousUser
@@ -25,7 +25,7 @@ from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpRespo
 from django.shortcuts import redirect
 from certificates import api as certs_api
 from edxmako.shortcuts import render_to_response, render_to_string, marketing_link
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from django.views.decorators.cache import cache_control
 from ipware.ip import get_ip
 from markupsafe import escape

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -25,7 +25,7 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.cache import cache_control
 from django.views.generic.base import TemplateView
 from django.views.decorators.http import condition
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from edxmako.shortcuts import render_to_response
 import mongoengine
 from path import Path as path

--- a/lms/djangoapps/debug/views.py
+++ b/lms/djangoapps/debug/views.py
@@ -7,7 +7,7 @@ from django.http import Http404, HttpResponse, HttpResponseNotFound
 from django.contrib.auth.decorators import login_required
 from django.utils.html import escape
 
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from edxmako.shortcuts import render_to_response
 
 from codejail.safe_exec import safe_exec

--- a/lms/djangoapps/django_comment_client/base/views.py
+++ b/lms/djangoapps/django_comment_client/base/views.py
@@ -9,7 +9,7 @@ from django.contrib.auth.models import User
 from django.core import exceptions
 from django.http import Http404, HttpResponseBadRequest
 from django.utils.translation import ugettext as _
-from django.views.decorators import csrf
+from edraak_backends import csrf
 from django.views.decorators.http import require_GET, require_POST
 from opaque_keys.edx.keys import CourseKey
 

--- a/lms/djangoapps/django_comment_client/forum/views.py
+++ b/lms/djangoapps/django_comment_client/forum/views.py
@@ -8,7 +8,7 @@ import logging
 
 from django.contrib.auth.decorators import login_required
 from django.conf import settings
-from django.core.context_processors import csrf
+from edraak_backends.context_processors import csrf
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
 from django.http import Http404, HttpResponseBadRequest

--- a/lms/djangoapps/edraak_contact/views.py
+++ b/lms/djangoapps/edraak_contact/views.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from django.conf import settings
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from django.core.mail import send_mail
 
 from edxmako.shortcuts import render_to_response, render_to_string

--- a/lms/djangoapps/edraak_forus/views.py
+++ b/lms/djangoapps/edraak_forus/views.py
@@ -17,7 +17,7 @@ from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from util.json_request import JsonResponse
 
 from student_account.views import _local_server_get
-from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
+from edraak_backends.csrf import csrf_exempt, ensure_csrf_cookie
 from django.utils.decorators import method_decorator
 from django.core.exceptions import ValidationError
 from student.cookies import delete_logged_in_cookies

--- a/lms/djangoapps/edraak_misc/views.py
+++ b/lms/djangoapps/edraak_misc/views.py
@@ -1,4 +1,4 @@
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from django.conf import settings
 from django.db import transaction
 from django.contrib.auth.decorators import login_required

--- a/lms/djangoapps/instructor/hint_manager.py
+++ b/lms/djangoapps/instructor/hint_manager.py
@@ -11,7 +11,7 @@ import json
 import re
 
 from django.http import HttpResponse, Http404
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 
 from edxmako.shortcuts import render_to_response, render_to_string
 

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -12,7 +12,7 @@ import re
 import time
 import requests
 from django.conf import settings
-from django.views.decorators.csrf import ensure_csrf_cookie, csrf_exempt
+from edraak_backends.csrf import ensure_csrf_cookie, csrf_exempt
 from django.views.decorators.http import require_POST, require_http_methods
 from django.views.decorators.cache import cache_control
 from django.core.exceptions import ValidationError, PermissionDenied

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -12,7 +12,7 @@ import pytz
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_POST
 from django.utils.translation import ugettext as _, ugettext_noop
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from django.views.decorators.cache import cache_control
 from edxmako.shortcuts import render_to_response
 from django.core.urlresolvers import reverse

--- a/lms/djangoapps/instructor/views/legacy.py
+++ b/lms/djangoapps/instructor/views/legacy.py
@@ -22,7 +22,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import transaction
 from django.http import HttpResponse
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from django.views.decorators.cache import cache_control
 from django.core.urlresolvers import reverse
 from django.core.mail import send_mail

--- a/lms/djangoapps/lms_migration/migrate.py
+++ b/lms/djangoapps/lms_migration/migrate.py
@@ -12,10 +12,7 @@ from django.http import HttpResponse
 from django.conf import settings
 import track.views
 
-try:
-    from django.views.decorators.csrf import csrf_exempt
-except ImportError:
-    from django.contrib.csrf.middleware import csrf_exempt
+from edraak_backends.csrf import csrf_exempt
 
 log = logging.getLogger("edx.lms_migrate")
 LOCAL_DEBUG = True

--- a/lms/djangoapps/lti_provider/views.py
+++ b/lms/djangoapps/lti_provider/views.py
@@ -4,7 +4,7 @@ LTI Provider view functions
 
 from django.conf import settings
 from django.http import HttpResponseBadRequest, HttpResponseForbidden, Http404
-from django.views.decorators.csrf import csrf_exempt
+from edraak_backends.csrf import csrf_exempt
 import logging
 
 from lti_provider.outcomes import store_outcome_parameters

--- a/lms/djangoapps/shoppingcart/tests/payment_fake.py
+++ b/lms/djangoapps/shoppingcart/tests/payment_fake.py
@@ -14,7 +14,7 @@ set to "success" or "failure".  The view defaults to payment success.
 """
 
 from django.views.generic.base import View
-from django.views.decorators.csrf import csrf_exempt
+from edraak_backends.csrf import csrf_exempt
 from django.http import HttpResponse, HttpResponseBadRequest
 from edxmako.shortcuts import render_to_response
 

--- a/lms/djangoapps/shoppingcart/views.py
+++ b/lms/djangoapps/shoppingcart/views.py
@@ -16,7 +16,7 @@ from course_modes.models import CourseMode
 from util.json_request import JsonResponse
 from django.views.decorators.http import require_POST, require_http_methods
 from django.core.urlresolvers import reverse
-from django.views.decorators.csrf import csrf_exempt
+from edraak_backends.csrf import csrf_exempt
 from util.bad_request_rate_limiter import BadRequestRateLimiter
 from util.date_utils import get_default_time_display
 from django.contrib.auth.decorators import login_required

--- a/lms/djangoapps/static_template_view/views.py
+++ b/lms/djangoapps/static_template_view/views.py
@@ -8,7 +8,7 @@ from mako.exceptions import TopLevelLookupException
 from django.shortcuts import redirect
 from django.conf import settings
 from django.http import HttpResponseNotFound, HttpResponseServerError, Http404
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 
 from util.cache import cache_if_anonymous
 

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -15,7 +15,7 @@ from django.http import HttpRequest
 from django_countries import countries
 from django.core.urlresolvers import reverse, resolve
 from django.utils.translation import ugettext as _
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods
 
 from lang_pref.api import released_languages

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -21,7 +21,7 @@ from django.shortcuts import redirect
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _, ugettext_lazy
-from django.views.decorators.csrf import csrf_exempt
+from edraak_backends.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.views.generic.base import View, RedirectView
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1128,7 +1128,7 @@ MIDDLEWARE_CLASSES = (
     'corsheaders.middleware.CorsMiddleware',
     'cors_csrf.middleware.CorsCSRFMiddleware',
     'cors_csrf.middleware.CsrfCrossDomainCookieMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
+    'edraak_backends.middleware.EdraakCsrfViewMiddleware',
 
     'splash.middleware.SplashMiddleware',
 
@@ -1933,6 +1933,7 @@ INSTALLED_APPS = (
     'edraak_ratelimit',
     'edraak_university',
     'edraak_specializations',
+    'edraak_backends',
 
     'lms.djangoapps.lms_xblock',
 

--- a/lms/envs/load_test.py
+++ b/lms/envs/load_test.py
@@ -11,7 +11,8 @@ from .aws import *
 # Disable CSRF for load testing
 EXCLUDE_CSRF = lambda elem: elem not in [
     'django.core.context_processors.csrf',
-    'django.middleware.csrf.CsrfViewMiddleware'
+    'edraak_backends.context_processors.csrf',
+    'edraak_backends.middleware.EdraakCsrfViewMiddleware',
 ]
 DEFAULT_TEMPLATE_ENGINE['OPTIONS']['context_processors'] = filter(
     EXCLUDE_CSRF, DEFAULT_TEMPLATE_ENGINE['OPTIONS']['context_processors']

--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -2,7 +2,7 @@
 Views related to course groups functionality.
 """
 
-from django.views.decorators.csrf import ensure_csrf_cookie
+from edraak_backends.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_POST
 from django.contrib.auth.models import User
 from django.core.paginator import Paginator, EmptyPage

--- a/openedx/core/djangoapps/credit/views.py
+++ b/openedx/core/djangoapps/credit/views.py
@@ -7,7 +7,7 @@ import datetime
 
 from django.conf import settings
 from django.utils.decorators import method_decorator
-from django.views.decorators.csrf import csrf_exempt
+from edraak_backends.csrf import csrf_exempt
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 import pytz

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -8,7 +8,7 @@ from django.core.urlresolvers import reverse
 from django.core.exceptions import ImproperlyConfigured, NON_FIELD_ERRORS, ValidationError
 from django.utils.translation import ugettext as _
 from django.utils.decorators import method_decorator
-from django.views.decorators.csrf import ensure_csrf_cookie, csrf_protect, csrf_exempt
+from edraak_backends.csrf import ensure_csrf_cookie, csrf_protect, csrf_exempt
 from opaque_keys.edx import locator
 from rest_framework import authentication
 from rest_framework import filters


### PR DESCRIPTION
Overrides built-in `CsrfViewMiddleware` middleware to accept and generate CSRF key with length of 64 characters instead of 32 because the key length is hardcoded in the middleware module. The new middleware is called `EdraakCsrfViewMiddleware` (will be found in `common/djangoapps/edraak_backends` app).

`Edraak-Programs` (**Django 1.11**): accepts/generates **64** CSRF key length.
`Edx-Platform` (**Django 1.8**): accepts/generates **32** CSRF key length.
`Marketing-Site` (**Django 1.8**): accepts/generates **32** CSRF key length.

This PR will make Edx-Platform accept and generate 64 CSRF key length instead of 32.

Another [PR](https://github.com/Edraak/marketing-site/pull/256) will be created for `Marketing-Site` to align all Edraak components with **64** CSRF key length.