### PR TITLE
Fix/salah/csrf cross domain

### DIFF
--- a/lms/djangoapps/edraak_dummy/urls.py
+++ b/lms/djangoapps/edraak_dummy/urls.py
@@ -1,0 +1,6 @@
+from django.conf.urls import patterns, url
+from edraak_dummy.views import SetCSRFDummyView
+
+urlpatterns = patterns('',  # nopep8
+    url('^edraak_set/csrf', SetCSRFDummyView.as_view(), name='edraak_setlang'),
+)

--- a/lms/djangoapps/edraak_dummy/views.py
+++ b/lms/djangoapps/edraak_dummy/views.py
@@ -1,0 +1,59 @@
+from django.utils.decorators import method_decorator
+
+from openedx.core.lib.api.permissions import ApiKeyHeaderPermission, ApiKeyHeaderPermissionIsAuthenticated
+from rest_framework.response import Response
+from rest_framework.throttling import UserRateThrottle
+from rest_framework.views import APIView
+from cors_csrf.decorators import ensure_csrf_cookie_cross_domain
+from cors_csrf.authentication import SessionAuthenticationCrossDomainCsrf
+from openedx.core.lib.api.authentication import (
+    SessionAuthenticationAllowInactiveUser,
+    OAuth2AuthenticationAllowInactiveUser,
+)
+
+
+from util.disable_rate_limit import can_disable_rate_limit
+
+class ApiKeyPermissionMixIn(object):
+    """
+    This mixin is used to provide a convenience function for doing individual permission checks
+    for the presence of API keys.
+    """
+    def has_api_key_permissions(self, request):
+        """
+        Checks to see if the request was made by a server with an API key.
+
+        Args:
+            request (Request): the request being made into the view
+
+        Return:
+            True if the request has been made with a valid API key
+            False otherwise
+        """
+        return ApiKeyHeaderPermission().has_permission(request, self)
+
+
+class EnrollmentUserThrottle(UserRateThrottle, ApiKeyPermissionMixIn):
+    """Limit the number of requests users can make to the enrollment API."""
+    rate = '40/minute'
+
+    def allow_request(self, request, view):
+        return self.has_api_key_permissions(request) or super(EnrollmentUserThrottle, self).allow_request(request, view)
+
+
+class EnrollmentCrossDomainSessionAuth(SessionAuthenticationAllowInactiveUser, SessionAuthenticationCrossDomainCsrf):
+    """Session authentication that allows inactive users and cross-domain requests. """
+    pass
+
+
+@can_disable_rate_limit
+class SetCSRFDummyView(APIView):
+    """
+    """
+    throttle_classes = EnrollmentUserThrottle,
+
+    # we need to support
+    # cross-domain CSRF.
+    @method_decorator(ensure_csrf_cookie_cross_domain)
+    def get(self, request):
+        return Response({})

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1934,6 +1934,7 @@ INSTALLED_APPS = (
     'edraak_ratelimit',
     'edraak_university',
     'edraak_specializations',
+    'edraak_dummy',
 
     'lms.djangoapps.lms_xblock',
 

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -89,6 +89,7 @@ urlpatterns = (
     url(r'', include('edraak_bayt.urls')),
     url(r'^certificate/', include('edraak_certificates.urls')),
     url(r'^university/', include('edraak_university.urls')),
+    url(r'', include('edraak_dummy.urls')),
 
     # Feedback Form endpoint
     url(r'^submit_feedback$', 'util.views.submit_feedback'),


### PR DESCRIPTION
### Description
Creating a dummy endpoint to regenerate CSRF token. This is necessary between progs and edx-platform as progs is now on django 1.11 which generates 64 bit csrf token unlike edx on django 1.8. So this is a very rough workaround until we upgrade edX to latest and then this will be obsolete.

### Related PRs
https://github.com/Edraak/edraak-programs/pull/415