### PR TITLE
Track k12 users

### DIFF
--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -38,7 +38,7 @@
                 this.errorMessage = data.thirdPartyAuth.errorMessage || '';
                 this.platformName = data.platformName;
                 this.autoSubmit = data.thirdPartyAuth.autoSubmitRegForm;
-
+                this.eventLabel = $.cookie('k12-landing') ? 'K12' : 'Universal';
                 this.listenTo( this.model, 'sync', this.saveSuccess );
             },
 
@@ -79,19 +79,19 @@
             },
 
             saveSuccess: function() {
-                // Edraak (google-analytics): Send event on registration success
+
                 if (ga) {
                   ga('send', 'event', {
                     eventCategory: 'Registration',
                     eventAction: 'Submit',
-                    eventLabel: 'Register',
+                    eventLabel: this.eventLabel,
                     eventValue: 1,
                     transport: 'beacon'
                   });
                 }
 
                 if (fbq) {
-                  fbq('track', 'CompleteRegistration', {status: 'successful'});
+                  fbq('track', 'CompleteRegistration', {status: 'successful', content_name: this.eventLabel});
                 }
 
                 if (snaptr) {
@@ -103,17 +103,18 @@
 
             saveError: function( error ) {
                 // Edraak (google-analytics): Send event on registration failure
+
                 if (ga) {
                   ga('send', 'event', {
                     eventCategory: 'Registration',
                     eventAction: 'Submit',
-                    eventLabel: 'Register',
+                    eventLabel: this.eventLabel,
                     eventValue: 0,
                     transport: 'beacon'
                   });
                 }
                 if (fbq) {
-                  fbq('track', 'CompleteRegistration', {status: 'failed'});
+                  fbq('track', 'CompleteRegistration', {status: 'failed', content_name: this.eventLabel});
                 }
                 if(snaptr) {
                   snaptr('track', 'SIGN_UP', {success: 0});


### PR DESCRIPTION
### Description

For the K12 campaign, the marketing agency has requested to send a custom event only for users coming from the K12 campaign landing page, thus the solution here is linked with an edX PR (see below) whereby whenever an anonymous user accesses this page, a cookie is set 'k12-landing', and in edX, if the cookie is set, change the event label to 'K12'.

### Other PRs
https://github.com/Edraak/marketing-site/pull/274