### PR TITLE
Add check_access flag to enrollment API

### DIFF
--- a/common/djangoapps/enrollment/api.py
+++ b/common/djangoapps/enrollment/api.py
@@ -142,7 +142,7 @@ def get_enrollment(user_id, course_id, request=None):
 
 
 def add_enrollment(user_id, course_id, mode=None, is_active=True,
-                   request=None):
+                   check_access=True, request=None):
     """Enrolls a user in a course.
 
     Enrolls a user in a course. If the mode is not specified, this will default to `CourseMode.DEFAULT_MODE_SLUG`.
@@ -156,6 +156,7 @@ def add_enrollment(user_id, course_id, mode=None, is_active=True,
             'professional'. If not specified, this defaults to the default course mode.
         is_active (boolean): Optional argument for making the new enrollment inactive. If not specified, is_active
             defaults to True.
+        check_access (boolean): Optional argument for checking enrollment access when enrolling a user in a course
 
     Returns:
         A serializable dictionary of the new course enrollment.
@@ -194,6 +195,7 @@ def add_enrollment(user_id, course_id, mode=None, is_active=True,
     _validate_course_mode(course_id, mode, is_active=is_active)
     return _data_api().create_course_enrollment(user_id, course_id,
                                                 mode, is_active,
+                                                check_access,
                                                 request=request)
 
 

--- a/common/djangoapps/enrollment/data.py
+++ b/common/djangoapps/enrollment/data.py
@@ -118,7 +118,7 @@ def get_course_enrollment(username, course_id, request=None):
 
 
 def create_course_enrollment(username, course_id, mode, is_active,
-                             request=None):
+                             check_access=True, request=None):
     """Create a new course enrollment for the given user.
 
     Creates a new course enrollment for the specified user username.
@@ -149,7 +149,7 @@ def create_course_enrollment(username, course_id, mode, is_active,
         raise UserNotFoundError(msg)
 
     try:
-        enrollment = CourseEnrollment.enroll(user, course_key, check_access=True)
+        enrollment = CourseEnrollment.enroll(user, course_key, check_access=check_access)
         return _update_enrollment(enrollment, is_active=is_active, mode=mode)
     except NonExistentCourseError as err:
         raise CourseNotFoundError(err.message)

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -509,6 +509,10 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
         username = request.data.get('user', request.user.username)
         course_id = request.data.get('course_details', {}).get('course_id')
 
+        # Used to enroll a user in a course without checking enrollment access
+        # (we need this flag for specialization courses).
+        check_access = request.data.get('check_access', True)
+
         if not course_id:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
@@ -612,8 +616,11 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
                 )
             else:
                 # Will reactivate inactive enrollments.
-                response = api.add_enrollment(username, unicode(
-                    course_id), mode=mode, is_active=is_active,
+                response = api.add_enrollment(username,
+                                              unicode(course_id),
+                                              mode=mode,
+                                              is_active=is_active,
+                                              check_access=check_access,
                                               request=request)
 
             email_opt_in = request.data.get('email_opt_in', None)


### PR DESCRIPTION
### Description
A user must be enrolled in a specialization course without checking enrollment access (course enrollment end date, etc) to prevent UX issues, so a `check_access` flag has been added to the `Enrollment` API view.