### PR TITLE
CSRF issue on generating certificate, hacky soulation for now

### DIFF
--- a/lms/templates/edraak_certificates/issue.html
+++ b/lms/templates/edraak_certificates/issue.html
@@ -34,8 +34,12 @@
       $.ajax({
         url: "${reverse('edraak_certificates_check_status', args=[course_id])}",
         method: 'GET',
+        statusCode: {
+            500: function() {
+              location.reload();
+            }
+        },
         success: function(response) {
-          console.log(response);
           if(response['is_downloadable']) {
             location.reload();
           }


### PR DESCRIPTION
This PR resolved an issue that arises on some PCs due to CSRF incompatibility between progs and edX. Which will be resolved after we migrate edX to Hawthorn. The basic idea is the backend doesn't understand the sent CSRF which results in an Anonymous user object on the request, thus a 500 issue. A workaround is to reload on edX and that will generate a new valid CSRF for the logged in user.